### PR TITLE
Stop the app being killed with 0xdead10cc during database writes

### DIFF
--- a/.claude/skills/roam-crash-triage/SKILL.md
+++ b/.claude/skills/roam-crash-triage/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: roam-crash-triage
+description: Triage Roam crash reports through the backend API - list unreviewed crashes, read Discord threads and messages with pagination, stream symbolicated reports and other attachments, post replies, and mark threads reviewed. Use when asked to look at crashes, check what crashes are outstanding, read a crash report or thread, reply to a crash, or work through the crash review queue. Needs only BACKEND_URL and BACKEND_API_KEY - never a Discord token.
+---
+
+# Roam crash triage
+
+Everything here goes through the Roam backend, which proxies Discord using its
+own bot credentials. **You never need a Discord token.** Two environment
+variables are enough:
+
+```bash
+export BACKEND_URL=https://backend.roam.msd3.io
+export BACKEND_API_KEY=...            # sent as the x-api-key header
+```
+
+A helper script wraps the endpoints below:
+
+```bash
+python3 scripts/roam_crashes.py --help
+```
+
+## How crash review works
+
+When a crash finishes symbolicating, the backend posts `symbolicated.txt` into
+the reporter's Discord thread and records the crash in `crash_reviews`. It then
+runs the report against the auto-review rules:
+
+- **A rule matches** → the backend replies in-thread with the known diagnosis
+  and marks the thread reviewed as `auto:<rule id>`. Nothing left to do.
+- **No rule matches** → the thread stays unreviewed. That is the queue you work.
+
+A thread is unreviewed when it was never reviewed *or* when a newer crash
+arrived after the last review, so marking a thread reviewed silences it only
+until its next crash.
+
+## Start here: what needs attention
+
+```bash
+curl -s -H "x-api-key: $BACKEND_API_KEY" \
+  "$BACKEND_URL/v2/crashes?unreviewed=true&limit=50"
+```
+
+Each entry carries enough to triage without downloading anything:
+`thread_id`, `latest_crash_message_id`, `latest_crash_at_ms`, `app_version`,
+`device_type`, `os_version`, `exception_type`, `signal`, `termination_code`,
+and the review fields.
+
+Filter and page:
+
+| Query param | Meaning |
+|---|---|
+| `unreviewed=true` | only threads needing attention |
+| `app_version=1.50` | exact match on the crash's `appVersion` |
+| `before_ms=<ms>` | page backwards; pass the previous page's `next_before_ms` |
+| `limit=<n>` | 1–200, default 50 |
+
+`next_before_ms` in the response is the cursor for the next page, or `null` on
+the last page. Loop until it is `null`.
+
+One thread:
+
+```bash
+curl -s -H "x-api-key: $BACKEND_API_KEY" "$BACKEND_URL/v2/crashes/<thread_id>"
+```
+
+## Reading a thread
+
+List messages, newest first (`limit` 1–100, default 50):
+
+```bash
+curl -s -H "x-api-key: $BACKEND_API_KEY" \
+  "$BACKEND_URL/v2/discord/threads/<thread_id>/messages?limit=50"
+```
+
+Page further back with `before=<message_id>`, or forward with
+`after=<message_id>`. IDs are strings — snowflakes exceed JavaScript's safe
+integer range, so every id in these APIs is a string on the wire.
+
+One message:
+
+```bash
+curl -s -H "x-api-key: $BACKEND_API_KEY" \
+  "$BACKEND_URL/v2/discord/threads/<thread_id>/messages/<message_id>"
+```
+
+All threads in the support forum (`archived_pages` walks 100 archived threads
+per page, 0 = active only, max 20):
+
+```bash
+curl -s -H "x-api-key: $BACKEND_API_KEY" \
+  "$BACKEND_URL/v2/discord/threads?archived_pages=3"
+```
+
+## Downloading documents
+
+Attachments stream straight through the backend from Discord's CDN — nothing is
+buffered server-side, so large diagnostics dumps are fine. Take the
+`attachments[].id` from a message and:
+
+```bash
+curl -s -H "x-api-key: $BACKEND_API_KEY" \
+  "$BACKEND_URL/v2/discord/threads/<thread_id>/messages/<message_id>/attachments/<attachment_id>" \
+  -o symbolicated.txt
+```
+
+Write it to a file and read that, rather than piping a whole report into
+context. The interesting parts of a symbolicated report are:
+
+- `Termination reason:` and `Diagnosis:` — present when the payload carried one;
+  these name the OS policy that killed the process
+- the `Metadata:` block — `exceptionType`, `signal`, `appVersion`, `deviceType`
+- the thread marked `(attributed)` — the only stack that caused the crash
+
+Read the attributed thread. Other threads are usually idle and will mislead you.
+
+## Replying and marking reviewed
+
+Post a reply (mentions are always suppressed):
+
+```bash
+curl -s -X POST -H "x-api-key: $BACKEND_API_KEY" -H "Content-Type: application/json" \
+  "$BACKEND_URL/v2/discord/threads/<thread_id>/messages" \
+  -d '{"content": "...", "reply_to_message_id": "<crash_message_id>"}'
+```
+
+Then mark the thread reviewed. Every field is optional:
+
+```bash
+curl -s -X POST -H "x-api-key: $BACKEND_API_KEY" -H "Content-Type: application/json" \
+  "$BACKEND_URL/v2/crashes/<thread_id>/review" \
+  -d '{"reviewed_by": "scott", "reviewed_message_id": "<reply_id>", "note": "..."}'
+```
+
+Reopen one you want to revisit:
+
+```bash
+curl -s -X DELETE -H "x-api-key: $BACKEND_API_KEY" \
+  "$BACKEND_URL/v2/crashes/<thread_id>/review"
+```
+
+## Auto-review rules
+
+```bash
+curl -s -H "x-api-key: $BACKEND_API_KEY" "$BACKEND_URL/v2/crashes/rules"
+```
+
+Rules live in `backend/src/crash_rules.rs` as a compiled-in list, matched in
+order with first-match-wins. Each has an `id`, optional `exception_type` /
+`signal` / `termination_code`, `all_of` / `none_of` substrings matched against
+the report text, and the `reply` markdown that gets posted.
+
+**When you diagnose a crash that recurs, add a rule** rather than replying by
+hand a second time. Put narrower rules first — several distinct bugs share
+`EXC_CRASH (10)` / `SIGKILL (9)`, so a rule keyed only on that pair will
+swallow others. Add a test in the same file covering the new report shape and
+asserting it does not steal matches from existing rules.
+
+## Working the queue
+
+1. `GET /v2/crashes?unreviewed=true` — see what is outstanding.
+2. For each, download the `symbolicated.txt` attachment and read the attributed
+   thread.
+3. Recognisable and already fixed → reply, mark reviewed, and consider adding a
+   rule so it self-serves next time.
+4. Novel → diagnose it, fix it in the app, then reply, mark reviewed, and add a
+   rule.
+
+Do not mark a thread reviewed without actually replying to it; the review flag
+is a record that someone answered, not that someone looked.

--- a/.claude/skills/roam-crash-triage/scripts/roam_crashes.py
+++ b/.claude/skills/roam-crash-triage/scripts/roam_crashes.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Roam crash triage over the backend API.
+
+Talks only to the Roam backend, which proxies Discord with its own bot
+credentials -- this needs BACKEND_URL and BACKEND_API_KEY, never a Discord
+token.
+
+    export BACKEND_URL=https://backend.roam.msd3.io
+    export BACKEND_API_KEY=...
+
+    roam_crashes.py unreviewed
+    roam_crashes.py unreviewed --app-version 1.50 --all-pages
+    roam_crashes.py messages <thread_id> --limit 20
+    roam_crashes.py download <thread_id> <message_id> --out ./reports
+    roam_crashes.py reply <thread_id> --reply-to <message_id> --file body.md
+    roam_crashes.py review <thread_id> --by scott --note "known issue"
+    roam_crashes.py rules
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TIMEOUT = 120
+
+
+def _config():
+    base = os.environ.get("BACKEND_URL")
+    key = os.environ.get("BACKEND_API_KEY")
+    if not base or not key:
+        sys.exit("Set BACKEND_URL and BACKEND_API_KEY")
+    return base.rstrip("/"), key
+
+
+def _request(path, method="GET", body=None, query=None):
+    base, key = _config()
+    url = base + path
+    if query:
+        clean = {k: v for k, v in query.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean)
+    req = urllib.request.Request(url, method=method)
+    req.add_header("x-api-key", key)
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        req.add_header("Content-Type", "application/json")
+    try:
+        return urllib.request.urlopen(req, data, timeout=TIMEOUT)
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")[:500]
+        sys.exit(f"HTTP {e.code} {method} {url}\n{detail}")
+
+
+def _json(path, method="GET", body=None, query=None):
+    with _request(path, method, body, query) as response:
+        raw = response.read()
+    return json.loads(raw) if raw else None
+
+
+def cmd_unreviewed(args):
+    crashes, before_ms = [], args.before_ms
+    while True:
+        page = _json(
+            "/v2/crashes",
+            query={
+                "unreviewed": "true" if not args.include_reviewed else "false",
+                "app_version": args.app_version,
+                "before_ms": before_ms,
+                "limit": args.limit,
+            },
+        )
+        crashes.extend(page["crashes"])
+        before_ms = page.get("next_before_ms")
+        if not args.all_pages or before_ms is None:
+            break
+
+    if args.json:
+        print(json.dumps(crashes, indent=2))
+        return
+    if not crashes:
+        print("Nothing outstanding.")
+        return
+    print(f"{len(crashes)} crash thread(s):\n")
+    for c in crashes:
+        flag = "UNREVIEWED" if _is_unreviewed(c) else f"reviewed by {c.get('reviewed_by')}"
+        print(f"  thread {c['thread_id']}  [{flag}]")
+        print(
+            f"    v{c.get('app_version') or '?'}  {c.get('device_type') or '?'}"
+            f"  {c.get('os_version') or '?'}"
+        )
+        print(
+            f"    exceptionType={c.get('exception_type')} signal={c.get('signal')}"
+            f" termination={c.get('termination_code') or '-'}"
+        )
+        if c.get("latest_crash_message_id"):
+            print(f"    crash message: {c['latest_crash_message_id']}")
+        print()
+
+
+def _is_unreviewed(crash):
+    reviewed_at = crash.get("reviewed_at_ms")
+    return reviewed_at is None or reviewed_at < crash["latest_crash_at_ms"]
+
+
+def cmd_messages(args):
+    messages = _json(
+        f"/v2/discord/threads/{args.thread_id}/messages",
+        query={"limit": args.limit, "before": args.before, "after": args.after},
+    )
+    if args.json:
+        print(json.dumps(messages, indent=2))
+        return
+    for m in messages:
+        stamp = (m.get("timestamp") or "")[:19]
+        print(f"[{stamp}] {m['id']} (author {m['author']['id']})")
+        content = (m.get("content") or "").strip()
+        if content:
+            for line in content.splitlines()[:6]:
+                print(f"    {line}")
+        for a in m.get("attachments", []):
+            print(f"    * attachment {a['id']}  {a['filename']}")
+        print()
+
+
+def cmd_download(args):
+    message = _json(f"/v2/discord/threads/{args.thread_id}/messages/{args.message_id}")
+    attachments = message.get("attachments", [])
+    if args.attachment_id:
+        attachments = [a for a in attachments if a["id"] == args.attachment_id]
+    if not attachments:
+        sys.exit("No matching attachments on that message")
+
+    os.makedirs(args.out, exist_ok=True)
+    for a in attachments:
+        target = os.path.join(args.out, f"{args.thread_id}_{args.message_id}_{a['filename']}")
+        path = (
+            f"/v2/discord/threads/{args.thread_id}/messages/{args.message_id}"
+            f"/attachments/{a['id']}"
+        )
+        # Streamed straight to disk; reports can be hundreds of KB and there is
+        # no reason to hold one in memory.
+        with _request(path) as response, open(target, "wb") as out:
+            shutil.copyfileobj(response, out)
+        print(f"wrote {target} ({os.path.getsize(target)} bytes)")
+
+
+def cmd_reply(args):
+    content = open(args.file, encoding="utf-8").read() if args.file else args.content
+    if not content:
+        sys.exit("Provide --content or --file")
+    posted = _json(
+        f"/v2/discord/threads/{args.thread_id}/messages",
+        method="POST",
+        body={
+            "content": content,
+            "reply_to_message_id": args.reply_to,
+            "notify": args.notify,
+        },
+    )
+    print(f"posted message {posted['id']} in thread {args.thread_id}")
+
+
+def cmd_review(args):
+    review = _json(
+        f"/v2/crashes/{args.thread_id}/review",
+        method="POST",
+        body={
+            "reviewed_by": args.by,
+            "reviewed_message_id": args.reviewed_message_id,
+            "matched_rule_id": args.rule,
+            "note": args.note,
+        },
+    )
+    print(f"thread {review['thread_id']} reviewed by {review.get('reviewed_by')}")
+
+
+def cmd_unreview(args):
+    review = _json(f"/v2/crashes/{args.thread_id}/review", method="DELETE")
+    print(f"thread {review['thread_id']} reopened")
+
+
+def cmd_rules(args):
+    rules = _json("/v2/crashes/rules")
+    if args.json:
+        print(json.dumps(rules, indent=2))
+        return
+    for r in rules:
+        print(f"{r['id']}\n    {r['title']}")
+        conditions = []
+        if r.get("exception_type") is not None:
+            conditions.append(f"exceptionType={r['exception_type']}")
+        if r.get("signal") is not None:
+            conditions.append(f"signal={r['signal']}")
+        if r.get("termination_code"):
+            conditions.append(f"code={r['termination_code']}")
+        if r.get("all_of"):
+            conditions.append("contains " + ", ".join(r["all_of"]))
+        print(f"    when: {'; '.join(conditions) or 'always'}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("unreviewed", help="list crash threads needing attention")
+    p.add_argument("--app-version")
+    p.add_argument("--before-ms", type=int)
+    p.add_argument("--limit", type=int, default=50)
+    p.add_argument("--all-pages", action="store_true")
+    p.add_argument("--include-reviewed", action="store_true")
+    p.add_argument("--json", action="store_true")
+    p.set_defaults(func=cmd_unreviewed)
+
+    p = sub.add_parser("messages", help="list messages in a thread, newest first")
+    p.add_argument("thread_id")
+    p.add_argument("--limit", type=int, default=50)
+    p.add_argument("--before", help="page backwards from this message id")
+    p.add_argument("--after", help="page forwards from this message id")
+    p.add_argument("--json", action="store_true")
+    p.set_defaults(func=cmd_messages)
+
+    p = sub.add_parser("download", help="stream a message's attachments to disk")
+    p.add_argument("thread_id")
+    p.add_argument("message_id")
+    p.add_argument("--attachment-id")
+    p.add_argument("--out", default="./reports")
+    p.set_defaults(func=cmd_download)
+
+    p = sub.add_parser("reply", help="post a reply into a thread")
+    p.add_argument("thread_id")
+    p.add_argument("--content")
+    p.add_argument("--file", help="read the message body from this file")
+    p.add_argument("--reply-to", help="message id to reply to")
+    p.add_argument("--notify", action="store_true")
+    p.set_defaults(func=cmd_reply)
+
+    p = sub.add_parser("review", help="mark a thread reviewed")
+    p.add_argument("thread_id")
+    p.add_argument("--by", default="manual")
+    p.add_argument("--reviewed-message-id")
+    p.add_argument("--rule")
+    p.add_argument("--note")
+    p.set_defaults(func=cmd_review)
+
+    p = sub.add_parser("unreview", help="reopen a thread for review")
+    p.add_argument("thread_id")
+    p.set_defaults(func=cmd_unreview)
+
+    p = sub.add_parser("rules", help="list auto-review rules")
+    p.add_argument("--json", action="store_true")
+    p.set_defaults(func=cmd_rules)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/Roam/MetricManager.swift
+++ b/Roam/MetricManager.swift
@@ -9,6 +9,64 @@ struct DiagnosticsRequest: Codable, Sendable {
     let installationInfo: InstallationInfo
 }
 
+/// `MXDiagnosticPayload.jsonRepresentation()` has not been carrying
+/// `terminationReason` / `virtualMemoryRegionInfo` in the payloads we receive,
+/// even though `MXCrashDiagnostic` exposes both as properties. They are the
+/// fields that say *why* the OS killed the process — without them an
+/// `EXC_CRASH` / `SIGKILL` report can only be narrowed to "some OS policy fired"
+/// rather than naming the policy (0xdead10cc, 0x8badf00d, and so on).
+///
+/// Read them off the diagnostic objects directly and merge them into
+/// `diagnosticMetaData`, which is where the backend report generator looks.
+/// Falls back to the unmodified representation if anything about the shape is
+/// unexpected, so a MetricKit format change can't cost us the whole upload.
+private func jsonRepresentationIncludingTerminationFields(_ payload: MXDiagnosticPayload) -> Data {
+    let data = payload.jsonRepresentation()
+
+    guard let crashDiagnostics = payload.crashDiagnostics, !crashDiagnostics.isEmpty,
+        var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+        var encodedCrashes = root["crashDiagnostics"] as? [[String: Any]],
+        encodedCrashes.count == crashDiagnostics.count
+    else {
+        Log.backend.notice("Uploading MetricKit payload without merged termination fields")
+        return data
+    }
+
+    var addedField = false
+    for (index, crashDiagnostic) in crashDiagnostics.enumerated() {
+        var encodedCrash = encodedCrashes[index]
+        var metaData = encodedCrash["diagnosticMetaData"] as? [String: Any] ?? [:]
+
+        if let terminationReason = crashDiagnostic.terminationReason,
+            metaData["terminationReason"] == nil
+        {
+            metaData["terminationReason"] = terminationReason
+            addedField = true
+        }
+
+        if let regionInfo = crashDiagnostic.virtualMemoryRegionInfo,
+            metaData["virtualMemoryRegionInfo"] == nil
+        {
+            metaData["virtualMemoryRegionInfo"] = regionInfo
+            addedField = true
+        }
+
+        encodedCrash["diagnosticMetaData"] = metaData
+        encodedCrashes[index] = encodedCrash
+    }
+
+    guard addedField else { return data }
+    root["crashDiagnostics"] = encodedCrashes
+
+    guard let merged = try? JSONSerialization.data(withJSONObject: root) else {
+        Log.backend.error("Failed to re-encode MetricKit payload with termination fields")
+        return data
+    }
+
+    Log.backend.notice("Merged MetricKit termination fields into crash payload")
+    return merged
+}
+
 final class RoamMetricManager: NSObject, MXMetricManagerSubscriber, Sendable {
     override init() {
         super.init()
@@ -28,7 +86,7 @@ final class RoamMetricManager: NSObject, MXMetricManagerSubscriber, Sendable {
             payload.crashDiagnostics?.isEmpty == false
         }) {
             let payloadData = payload.filter { $0.crashDiagnostics?.isEmpty == false }.map {
-                $0.jsonRepresentation()
+                jsonRepresentationIncludingTerminationFields($0)
             }
             Log.backend.notice(
                 "Sending \(payloadData.count, privacy: .public) crash diagnostics reports...")

--- a/Roam/Views/RemoteRoot.swift
+++ b/Roam/Views/RemoteRoot.swift
@@ -21,6 +21,8 @@ private let iPadMinContentHeight: CGFloat = 560
 struct RemoteRoot: View {
     @EnvironmentObject private var appDelegate: RoamAppDelegate
 
+    @Environment(\.scenePhase) private var scenePhase
+
     @State private var devicesLoader = DeviceListLoader(dataHandler: .shared)
     @State private var primaryDeviceLoader = PrimaryDeviceLoader(dataHandler: .shared)
     @State private var messageLoader = MessageListLoader(dataHandler: .shared)
@@ -40,6 +42,13 @@ struct RemoteRoot: View {
 
     private var runningInPreview: Bool {
         ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+
+    /// Automatic scanning stops while backgrounded so a discovery-driven database
+    /// write can't still be holding the app-group file lock when the process is
+    /// suspended (0xdead10cc).
+    private var discoveryPausedForBackground: Bool {
+        discoveryPaused(for: scenePhase)
     }
 
     private var settingsNavigationPathBinding: Binding<[NavigationDestination]> {
@@ -77,16 +86,24 @@ struct RemoteRoot: View {
                 guard !runningInPreview else { return }
                 await RoamDataHandler.shared.initialize()
             }
-            .task(id: "ssdp-\(scanAutomatically)", priority: .background) {
+            .task(id: "ssdp-\(scanAutomatically)-\(discoveryPausedForBackground)", priority: .background) {
                 guard !runningInPreview, scanAutomatically else { return }
+                guard !discoveryPausedForBackground else {
+                    Log.scanning.notice("RemoteRoot skipping continual SSDP scan while backgrounded")
+                    return
+                }
                 Log.scanning.notice("RemoteRoot starting continual SSDP scan")
                 await appDelegate.discoveryCoordinator.ssdpActor.scanSSDPContinually()
                 Log.scanning.notice("RemoteRoot continual SSDP scan returned")
             }
             .task(
-                id: "ipv4-\(scanAutomatically)-\(primaryDevice == nil)-\(String(describing: appDelegate.networkMonitor.networkConnection))"
+                id: "ipv4-\(scanAutomatically)-\(primaryDevice == nil)-\(discoveryPausedForBackground)-\(String(describing: appDelegate.networkMonitor.networkConnection))"
             ) {
                 guard !runningInPreview, scanAutomatically else { return }
+                guard !discoveryPausedForBackground else {
+                    Log.scanning.notice("RemoteRoot skipping IPV4 scan while backgrounded")
+                    return
+                }
                 guard primaryDevice == nil else { return }
                 Log.scanning.notice("RemoteRoot starting IPV4 scan")
                 await appDelegate.discoveryCoordinator.ipv4Actor.scanIPV4Once()

--- a/Shared/Backend/Discovery/DiscoveryActor.swift
+++ b/Shared/Backend/Discovery/DiscoveryActor.swift
@@ -228,6 +228,25 @@ private func discoveryNWInterfaceNames(_ interfaces: [NWInterface]) -> [String] 
     Array(Set(interfaces.map(\.name).filter { !isUnsupportedDiscoveryInterfaceName($0) })).sorted()
 }
 
+/// Whether automatic discovery must stop because the process is backgrounded.
+///
+/// Discovery writes every device it finds straight into the shared app-group
+/// database. Those writes hold an exclusive file lock on the container, and iOS
+/// kills an app that gets suspended while holding one (0xdead10cc). Stopping
+/// automatic scanning on the way to the background removes the main source of
+/// writes that can still be in flight at suspension time.
+///
+/// Only applies to automatic/continual scanning — a user-initiated pull-to-refresh
+/// only ever runs in the foreground. macOS has no equivalent suspension policy, so
+/// scanning keeps running there.
+func discoveryPaused(for scenePhase: ScenePhase) -> Bool {
+    #if os(macOS)
+        return false
+    #else
+        return scenePhase == .background
+    #endif
+}
+
 /// Run a single concurrent IPV4 + one-shot SSDP scan. Shared by every UI surface
 /// that exposes a manual "Scan / pull-to-refresh" affordance.
 func performManualDeviceScan(ipv4Actor: DeviceDiscoveryActor, ssdpActor: DeviceDiscoveryActor) async {

--- a/Shared/Backend/Discovery/SSDP/SSDPDiscovery.swift
+++ b/Shared/Backend/Discovery/SSDP/SSDPDiscovery.swift
@@ -11,6 +11,41 @@ enum SSDPError: Swift.Error, LocalizedError {
 }
 
 /// SSDP discovery for UPnP devices on the LAN.
+/// Closes a file descriptor exactly once, however many callers ask.
+///
+/// `withTaskCancellationHandler` can run its `onCancel` closure concurrently
+/// with — and on a different thread from — the operation body, so a socket that
+/// is closed both on cancellation and in the body's `defer` gets `close(2)`d
+/// twice. By then the kernel may well have handed that descriptor number to
+/// something else, and the second close lands on an unrelated file. When the
+/// new owner is a *guarded* descriptor (GRDB's SQLite handles and
+/// Network.framework both guard theirs) the process is killed outright with
+/// `EXC_GUARD` — which `try? close()` cannot catch, because a Mach exception is
+/// not an errno.
+private final class CloseOnceFileDescriptor: @unchecked Sendable {
+    private let fileDescriptor: FileDescriptor
+    private let closed = OSAllocatedUnfairLock(initialState: false)
+
+    init(_ fileDescriptor: FileDescriptor) {
+        self.fileDescriptor = fileDescriptor
+    }
+
+    var wrapped: FileDescriptor { fileDescriptor }
+
+    func close() {
+        let shouldClose = closed.withLock { alreadyClosed -> Bool in
+            if alreadyClosed { return false }
+            alreadyClosed = true
+            return true
+        }
+        guard shouldClose else {
+            Log.scanning.notice("Skipping redundant SSDP socket close")
+            return
+        }
+        try? fileDescriptor.close()
+    }
+}
+
 /// Created using BSD sockets do to this bug: https://developer.apple.com/forums/thread/716339?page=1#769355022
 /// Code using Network framework shown below
 func scanDevicesContinually(
@@ -19,6 +54,7 @@ func scanDevicesContinually(
 ) async throws {
     Log.scanning.notice("Starting scan with interface \(interface ?? "nil", privacy: .public)")
     let socket = try FileDescriptor.socket(AF_INET, SOCK_DGRAM, 0)
+    let socketCloser = CloseOnceFileDescriptor(socket)
     // Setting nosigpipe due to https://developer.apple.com/forums/thread/773307
     try socket.setSocketOption(SOL_SOCKET, SO_NOSIGPIPE, 1 as CInt)
     try socket.setSocketOption(SOL_SOCKET, SO_REUSEPORT, 1 as CInt)
@@ -55,7 +91,7 @@ func scanDevicesContinually(
         defer {
             Log.scanning.notice("Terminating ssdp")
             sendingHandle?.cancel()
-            try? socket.close()
+            socketCloser.close()
         }
 
         Log.scanning.notice(
@@ -114,6 +150,9 @@ func scanDevicesContinually(
             }
         }
     } onCancel: {
-        try? socket.close()
+        // Closing here is what interrupts the blocking `receiveFrom` above; the
+        // body's `defer` then closes again as it unwinds. Route both through
+        // `socketCloser` so the descriptor is only ever handed to `close(2)` once.
+        socketCloser.close()
     }
 }

--- a/Shared/Backend/NetworkPermissionsCheck.swift
+++ b/Shared/Backend/NetworkPermissionsCheck.swift
@@ -198,8 +198,18 @@ func requestLocalNetworkAuthorization() async throws -> Bool {
 
         return first
     } onCancel: {
-        listener.cancel()
-        browser.cancel()
+        // `onCancel` runs synchronously on whichever thread cancels the task, and
+        // SwiftUI cancels `.task` work on the main thread while it applies a
+        // scene-phase change. `NWBrowser.cancel()` / `NWListener.cancel()` block
+        // on an internal Network.framework lock, so when `queue` is busy this
+        // stalls the main thread — long enough on app termination to be killed by
+        // the watchdog with 0x8BADF00D ("Failed to terminate gracefully after
+        // 5.0s"). Tear down on the queue these objects already run on so the
+        // cancelling thread is never blocked.
+        queue.async {
+            listener.cancel()
+            browser.cancel()
+        }
     }
 }
 #endif

--- a/Shared/Models/DataHandler.swift
+++ b/Shared/Models/DataHandler.swift
@@ -304,7 +304,7 @@ actor RoamDataHandler {
         }
     }
 
-    func retryOpeningPersistentDatabase() {
+    func retryOpeningPersistentDatabase() async {
         guard shouldRetryPersistentOpen else {
             persistentRetryTask?.cancel()
             persistentRetryTask = nil
@@ -321,13 +321,32 @@ actor RoamDataHandler {
         }
 
         let volatileSnapshot = database.exportSnapshot()
+        // Hoisted out of the closure below so it captures only local values
+        // rather than this actor's isolated state.
+        let rootPath = legacyRootPath
 
         do {
-            let persistentDatabase = try RoamDatabase(
-                databaseURL: persistentDatabaseURL,
-                lockURL: persistentLockURL,
-                legacyRootPath: legacyRootPath)
-            try persistentDatabase.mergeVolatileSnapshot(volatileSnapshot)
+            // Opening runs the migrations and the merge writes every table, all
+            // under the shared container's file lock. Being suspended underneath
+            // that gets the app killed with 0xdead10cc, same as a normal write.
+            let persistentDatabase = try await DatabaseWriteSuspensionGuard.protectingFromSuspension {
+                let opened = try RoamDatabase(
+                    databaseURL: persistentDatabaseURL,
+                    lockURL: persistentLockURL,
+                    legacyRootPath: rootPath)
+                try opened.mergeVolatileSnapshot(volatileSnapshot)
+                return opened
+            }
+
+            // This method is now re-entrant across the await above (the retry
+            // timer and the connectivity banner can both call it). If another
+            // call already installed a persistent database, drop ours — the
+            // merge landed in the same file either way.
+            guard !database.isPersistent else {
+                Log.backend.notice("Discarding duplicate persistent database open")
+                return
+            }
+
             database = persistentDatabase
             configureDatabaseCallbacks()
             handleExternalDatabaseChange()

--- a/Shared/Models/Database/DatabaseFileLock.swift
+++ b/Shared/Models/Database/DatabaseFileLock.swift
@@ -1,6 +1,41 @@
 import Darwin
 import Foundation
 
+/// Keeps the process alive for the duration of a persistent database write.
+///
+/// Persistent writes take an exclusive `flock` on a lock file inside the shared
+/// app-group container (see ``DatabaseFileLock``), on top of the SQLite/WAL locks
+/// GRDB holds on `Roam.sqlite` in that same container. If iOS suspends the process
+/// while any of those are held, the app is killed with `0xdead10cc` — surfaced
+/// through MetricKit as `EXC_CRASH` (10) / `SIGKILL` (9) — because a suspended
+/// lock holder can block `RoamWidgets` indefinitely.
+///
+/// Holding a background-task assertion across the write lets it commit and unlock
+/// before the process is allowed to suspend.
+enum DatabaseWriteSuspensionGuard {
+    /// Runs `body` with a "don't suspend me" assertion held.
+    ///
+    /// The assertion is only taken in the main app, where `QRunInBackgroundAssertion`
+    /// resolves to the cheap `UIApplication.beginBackgroundTask` implementation. The
+    /// widget and watch targets get `QActivityRunInBackgroundAssertion`, which parks a
+    /// Dispatch worker thread per instance and is documented as unsafe to allocate
+    /// freely — writes there stay unguarded rather than risk starving the thread pool.
+    /// macOS has no equivalent suspension policy.
+    static func protectingFromSuspension<T>(_ body: () async throws -> T) async rethrows -> T {
+        #if canImport(UIKit) && !os(watchOS) && !WIDGET
+            let assertion = await QRunInBackgroundAssertion(name: "roam-database-write")
+            defer {
+                Task { @MainActor in
+                    assertion.release()
+                }
+            }
+            return try await body()
+        #else
+            return try await body()
+        #endif
+    }
+}
+
 final class DatabaseFileLock: @unchecked Sendable {
     private let lockURL: URL
 

--- a/Shared/Models/Database/RoamDatabase.swift
+++ b/Shared/Models/Database/RoamDatabase.swift
@@ -289,10 +289,8 @@ final class RoamDatabase: @unchecked Sendable {
 
     private func write(_ body: (Database) throws -> Void) throws {
         do {
-            let nextSnapshot = try withExclusiveDatabaseLock {
-                try dbWriter.writeWithoutTransaction { db in
-                    try Self.performWrite(body, db: db)
-                }
+            let nextSnapshot = try dbWriter.writeWithoutTransaction { [fileLock] db in
+                try Self.performWrite(body, db: db, fileLock: fileLock)
             }
 
             stateLock.withLock {
@@ -309,13 +307,13 @@ final class RoamDatabase: @unchecked Sendable {
 
     private func writeAsync(_ body: @escaping @Sendable (Database) throws -> Void) async throws {
         do {
-            let nextSnapshot = try await dbWriter.writeWithoutTransaction { [fileLock] db in
-                if let fileLock {
-                    return try fileLock.withExclusiveLock {
-                        try Self.performWrite(body, db: db)
-                    }
+            // The write holds an flock on a lock file in the shared app-group
+            // container. Being suspended mid-write gets the app killed with
+            // 0xdead10cc, so hold a background assertion until it unlocks.
+            let nextSnapshot = try await DatabaseWriteSuspensionGuard.protectingFromSuspension {
+                try await dbWriter.writeWithoutTransaction { [fileLock] db in
+                    try Self.performWrite(body, db: db, fileLock: fileLock)
                 }
-                return try Self.performWrite(body, db: db)
             }
 
             stateLock.withLock {
@@ -383,8 +381,10 @@ final class RoamDatabase: @unchecked Sendable {
     func mergeVolatileSnapshot(_ source: RoamDataSnapshot) throws {
         guard isPersistent else { return }
 
-        let nextSnapshot = try withExclusiveDatabaseLock {
-            try dbWriter.writeWithoutTransaction { db in
+        // As in `performWrite`, the flock covers the transaction only; the trailing
+        // snapshot reload runs unlocked to keep the suspension window short.
+        let nextSnapshot = try dbWriter.writeWithoutTransaction { [fileLock] db in
+            try Self.withExclusiveDatabaseLock(fileLock) {
                 try db.inTransaction {
                     let existingSnapshot = try Self.loadSnapshot(from: db)
                     for device in source.devicesByID.values {
@@ -419,9 +419,9 @@ final class RoamDatabase: @unchecked Sendable {
                     try db.execute(sql: "UPDATE app_state SET revision = revision + 1 WHERE id = 1")
                     return .commit
                 }
-
-                return try Self.loadSnapshot(from: db)
             }
+
+            return try Self.loadSnapshot(from: db)
         }
 
         stateLock.withLock {
@@ -432,6 +432,13 @@ final class RoamDatabase: @unchecked Sendable {
     }
 
     private func withExclusiveDatabaseLock<T>(_ body: () throws -> T) throws -> T {
+        try Self.withExclusiveDatabaseLock(fileLock, body)
+    }
+
+    private static func withExclusiveDatabaseLock<T>(
+        _ fileLock: DatabaseFileLock?,
+        _ body: () throws -> T
+    ) throws -> T {
         if let fileLock {
             return try fileLock.withExclusiveLock(body)
         }
@@ -440,12 +447,20 @@ final class RoamDatabase: @unchecked Sendable {
 
     private static func performWrite(
         _ body: (Database) throws -> Void,
-        db: Database
+        db: Database,
+        fileLock: DatabaseFileLock?
     ) throws -> RoamDataSnapshot {
-        try db.inTransaction {
-            try body(db)
-            try db.execute(sql: "UPDATE app_state SET revision = revision + 1 WHERE id = 1")
-            return .commit
+        // Only the mutating transaction needs the cross-process file lock.
+        // Reloading the snapshot afterwards full-scans every table, and holding
+        // the flock across that widens the window in which a suspension gets the
+        // app killed with 0xdead10cc — so it runs unlocked, on the same writer
+        // connection.
+        try withExclusiveDatabaseLock(fileLock) {
+            try db.inTransaction {
+                try body(db)
+                try db.execute(sql: "UPDATE app_state SET revision = revision + 1 WHERE id = 1")
+                return .commit
+            }
         }
 
         return try Self.loadSnapshot(from: db)

--- a/Shared/Views/Settings/SettingsView.swift
+++ b/Shared/Views/Settings/SettingsView.swift
@@ -22,6 +22,8 @@ struct SettingsView: View {
     @Environment(\.openWindow) private var openWindow
 #endif
 
+    @Environment(\.scenePhase) private var scenePhase
+
     @State private var deviceListLoader = DeviceListLoader(dataHandler: .shared)
     @State private var hiddenDeviceListLoader = HiddenDeviceListLoader(dataHandler: .shared)
     @State private var messageLoader = MessageListLoader(dataHandler: .shared)
@@ -160,12 +162,18 @@ struct SettingsView: View {
                     allDevices = await RoamDataHandler.shared.requestAllDevices(allDeviceIds)
                 }
 #if !os(watchOS)
-                .task(id: "\(scanIpAutomatically)", priority: .background) {
+                .task(id: "\(scanIpAutomatically)-\(discoveryPaused(for: scenePhase))", priority: .background) {
                     Log.scanning.notice(
                         "SettingsView automatic SSDP task fired actorReady=\(ssdpActor != nil, privacy: .public) scanIpAutomatically=\(scanIpAutomatically, privacy: .public)"
                     )
                     guard scanIpAutomatically else {
                         Log.scanning.notice("SettingsView automatic SSDP task skipping because scanIpAutomatically is false")
+                        return
+                    }
+                    // Stop scanning while backgrounded so a discovery-driven write
+                    // can't hold the app-group file lock into suspension (0xdead10cc).
+                    guard !discoveryPaused(for: scenePhase) else {
+                        Log.scanning.notice("SettingsView automatic SSDP task skipping because the app is backgrounded")
                         return
                     }
                     guard let ssdpActor else {

--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -214,3 +214,62 @@ curl https://backend.roam.msd3.io/health
 ## Using the system
 
 Human support can send :translate: text, /translate text, or <@bot> :translate: text; reply-style :translate: also uses the referenced message text.
+
+## Crash review API
+
+Every endpoint below sits behind the existing `x-api-key` header, so a triage
+client needs `BACKEND_URL` and `BACKEND_API_KEY` and no Discord credentials of
+its own — the backend proxies Discord with its bot token. The
+`roam-crash-triage` skill in `.claude/skills/` drives all of this.
+
+When a symbolication completes, the backend records the crash against its
+thread and matches the report against the auto-review rules in
+`src/crash_rules.rs`. A match means it replies in-thread and marks the thread
+reviewed as `auto:<rule id>`; no match leaves the thread in the unreviewed
+queue for a human. A thread counts as unreviewed when it was never reviewed or
+when a newer crash landed after the last review.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/v2/crashes` | List tracked crashes. `unreviewed=true`, `app_version=`, `before_ms=`, `limit=` (1–200). Response carries `next_before_ms` as the page cursor. |
+| GET | `/v2/crashes/{thread_id}` | One thread's review state. |
+| POST | `/v2/crashes/{thread_id}/review` | Mark reviewed. Optional `reviewed_by`, `reviewed_message_id`, `matched_rule_id`, `note`. |
+| DELETE | `/v2/crashes/{thread_id}/review` | Reopen for review. |
+| GET | `/v2/crashes/rules` | The auto-review rules. |
+| GET | `/v2/discord/threads` | Forum threads. `archived_pages=` walks 100 archived per page (max 20). |
+| GET | `/v2/discord/threads/{id}/messages` | Messages, newest first. `before=`, `after=`, `limit=` (1–100). |
+| POST | `/v2/discord/threads/{id}/messages` | Post a reply. `content`, optional `reply_to_message_id`, `notify`. Mentions always suppressed. |
+| GET | `/v2/discord/threads/{id}/messages/{mid}` | One message. |
+| GET | `/v2/discord/threads/{id}/messages/{mid}/attachments/{aid}` | Stream an attachment through from Discord's CDN. Never buffered server-side. |
+
+Snowflake ids are strings in every request and response, since they exceed
+JavaScript's safe integer range.
+
+### Adding an auto-review rule
+
+Rules are a compiled-in list in `src/crash_rules.rs`, matched in order with
+first-match-wins, so narrower rules go first — several distinct bugs share
+`EXC_CRASH (10)` / `SIGKILL (9)`. Add a test alongside the rule that covers the
+new report shape and asserts it does not steal matches from existing rules.
+
+### Note: `crash_reviews` queries are runtime-checked
+
+They use `sqlx::query_as::<_, T>` rather than `query_as!`. `sqlx_sqlite`'s
+`column_nullable` calls `CStr::from_ptr` on the declared type from
+`sqlite3_table_column_metadata` without a null check, and SQLite returns NULL
+there for a column declared with no type — this schema has one, `users.device_id
+PRIMARY KEY` in the initial migration. Any `query_as!` that can reach a live
+database therefore segfaults rustc, which is exactly what `cargo sqlx prepare`
+does. Offline builds are fine; the cache just cannot be regenerated locally.
+
+Retry after any sqlx upgrade:
+
+```bash
+sqlite3 /tmp/probe.db < migrations/20250121024817_initial.up.sql
+DATABASE_URL="sqlite:///tmp/probe.db" cargo sqlx prepare -- --lib
+```
+
+If that completes without SIGSEGV, convert those queries back to `query_as!`
+and commit the regenerated `.sqlx` entries. Giving `users.device_id` an explicit
+`TEXT` type also fixes it (verified locally), but needs a table-rebuild
+migration against production data.

--- a/backend/migrations/20260811000000_crash_reviews.down.sql
+++ b/backend/migrations/20260811000000_crash_reviews.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_crash_reviews_recent;
+DROP INDEX IF EXISTS idx_crash_reviews_unreviewed;
+DROP TABLE IF EXISTS crash_reviews;

--- a/backend/migrations/20260811000000_crash_reviews.up.sql
+++ b/backend/migrations/20260811000000_crash_reviews.up.sql
@@ -1,0 +1,36 @@
+-- Review state for symbolicated crashes, keyed by the Discord thread the
+-- report was posted into.
+--
+-- A thread counts as *unreviewed* when it has never been reviewed, or when a
+-- newer crash arrived after the last review:
+--
+--     reviewed_at_ms IS NULL OR reviewed_at_ms < latest_crash_at_ms
+--
+-- Marking a thread reviewed therefore silences it only until its next crash,
+-- rather than permanently.
+CREATE TABLE crash_reviews (
+    thread_id INTEGER PRIMARY KEY,
+    -- Discord message carrying the most recent symbolicated.txt for this thread.
+    latest_crash_message_id INTEGER,
+    latest_crash_at_ms INTEGER NOT NULL,
+    -- Facts pulled out of the symbolicated report, so callers can triage from
+    -- the list endpoint without downloading every attachment.
+    app_version TEXT,
+    device_type TEXT,
+    os_version TEXT,
+    exception_type INTEGER,
+    signal INTEGER,
+    termination_code TEXT,
+    -- Review state.
+    reviewed_at_ms INTEGER,
+    reviewed_by TEXT,
+    reviewed_message_id INTEGER,
+    matched_rule_id TEXT,
+    review_note TEXT
+);
+
+CREATE INDEX idx_crash_reviews_unreviewed
+    ON crash_reviews (reviewed_at_ms, latest_crash_at_ms DESC);
+
+CREATE INDEX idx_crash_reviews_recent
+    ON crash_reviews (latest_crash_at_ms DESC);

--- a/backend/src/crash_rules.rs
+++ b/backend/src/crash_rules.rs
@@ -1,0 +1,295 @@
+//! Auto-review rules for symbolicated crash reports.
+//!
+//! When a symbolication completes, the rendered report is matched against
+//! [`RULES`]. The first rule that matches wins: the backend posts its
+//! explanation into the crash thread and marks the thread reviewed, attributed
+//! to `auto:<rule id>`. Anything that matches no rule stays unreviewed and
+//! shows up in `GET /v2/crashes/unreviewed` for a human.
+//!
+//! Rules are deliberately a compiled-in list rather than database rows: each
+//! one encodes a diagnosis that was worked out by reading stacks, and its reply
+//! text cites the fix that shipped alongside it. Adding a rule should be a code
+//! review, not a config edit.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Facts pulled out of a rendered symbolicated report, used for matching and
+/// stored on the review row so the list endpoints can triage without
+/// re-downloading attachments.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct CrashFacts {
+    pub app_version: Option<String>,
+    pub device_type: Option<String>,
+    pub os_version: Option<String>,
+    pub exception_type: Option<i64>,
+    pub signal: Option<i64>,
+    /// Termination code as lowercase hex with an `0x` prefix, e.g. `0x8badf00d`.
+    pub termination_code: Option<String>,
+}
+
+/// Reads `  key: value` out of a rendered report's metadata block.
+///
+/// Runs a handful of times per crash, so it builds its regex per call rather
+/// than carrying a cache.
+fn metadata_value(report: &str, key: &str) -> Option<String> {
+    let pattern = format!(r"(?m)^\s*{}: (.+)$", regex::escape(key));
+    let regex = Regex::new(&pattern).ok()?;
+    regex
+        .captures(report)
+        .map(|caps| caps[1].trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Extract the `Code 0x...` value out of a termination reason line.
+fn termination_code(report: &str) -> Option<String> {
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)code[: ]\s*0x([0-9a-f]+)").expect("valid code regex"));
+    let reason = metadata_value(report, "terminationReason")
+        .or_else(|| metadata_value(report, "Termination reason"))?;
+    RE.captures(&reason)
+        .map(|caps| format!("0x{}", caps[1].to_ascii_lowercase()))
+}
+
+impl CrashFacts {
+    pub fn from_report(report: &str) -> Self {
+        Self {
+            app_version: metadata_value(report, "appVersion"),
+            device_type: metadata_value(report, "deviceType"),
+            os_version: metadata_value(report, "osVersion"),
+            exception_type: metadata_value(report, "exceptionType")
+                .and_then(|v| v.parse().ok()),
+            signal: metadata_value(report, "signal").and_then(|v| v.parse().ok()),
+            termination_code: termination_code(report),
+        }
+    }
+}
+
+/// A single auto-review rule. All specified conditions must hold.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CrashRule {
+    pub id: &'static str,
+    pub title: &'static str,
+    /// Mach exception type, e.g. 10 for `EXC_CRASH`, 12 for `EXC_GUARD`.
+    pub exception_type: Option<i64>,
+    pub signal: Option<i64>,
+    /// Lowercase hex termination code, e.g. `0x8badf00d`.
+    pub termination_code: Option<&'static str>,
+    /// Substrings that must all appear somewhere in the report (stack frames).
+    pub all_of: &'static [&'static str],
+    /// Substrings that must not appear. Used to keep rules from overlapping.
+    pub none_of: &'static [&'static str],
+    /// Markdown posted into the thread when this rule matches.
+    pub reply: &'static str,
+}
+
+impl CrashRule {
+    pub fn matches(&self, report: &str, facts: &CrashFacts) -> bool {
+        if let Some(expected) = self.exception_type {
+            if facts.exception_type != Some(expected) {
+                return false;
+            }
+        }
+        if let Some(expected) = self.signal {
+            if facts.signal != Some(expected) {
+                return false;
+            }
+        }
+        if let Some(expected) = self.termination_code {
+            if facts.termination_code.as_deref() != Some(expected) {
+                return false;
+            }
+        }
+        if !self.all_of.iter().all(|needle| report.contains(needle)) {
+            return false;
+        }
+        if self.none_of.iter().any(|needle| report.contains(needle)) {
+            return false;
+        }
+        true
+    }
+}
+
+/// Returns the first rule matching the report, if any.
+pub fn match_rule(report: &str, facts: &CrashFacts) -> Option<&'static CrashRule> {
+    RULES.iter().find(|rule| rule.matches(report, facts))
+}
+
+const DEAD10CC_REPLY: &str = ":ninja: **Auto-review: `0xdead10cc` — suspended while holding the database lock**
+
+`EXC_CRASH (10)` / `SIGKILL (9)` with the attributed thread in the middle of a database write. This is not a fault in the app's own code — iOS killed the process deliberately.
+
+Persistent writes hold an exclusive `flock` on a lock file in the shared app-group container, on top of the SQLite/WAL locks on `Roam.sqlite` beside it. A suspended process still holding those can block the widget extension indefinitely, so the system terminates it.
+
+**Known cause, fix shipped:**
+- a background-task assertion is held across every persistent write, so the process stays alive long enough to commit and release the lock
+- the file lock covers the transaction only — it used to be held across a full snapshot reload that scans every table
+- automatic device discovery stops when the app is backgrounded, removing the main source of writes still in flight at suspension time
+
+_Matched automatically by rule `database-lock-suspension`._";
+
+const EXC_GUARD_REPLY: &str = ":ninja: **Auto-review: `EXC_GUARD` — the SSDP socket was closed twice**
+
+`EXC_GUARD (12)`, attributed to `close()` inside the `defer` in `scanDevicesContinually`.
+
+That function closed its UDP socket in two places: the `onCancel` handler of `withTaskCancellationHandler` (which is what interrupts the blocking `receiveFrom`), and the body's own `defer` as it unwinds. On cancellation both run, so `close(2)` fires twice on the same descriptor. By the second call the kernel has usually reused that number, and when the new owner is a *guarded* descriptor — GRDB's SQLite handles and Network.framework both guard theirs — the process is killed on the spot.
+
+`try? socket.close()` cannot defend against this: `EXC_GUARD` is a Mach exception, not an `errno`.
+
+**Known cause, fix shipped:** both paths now go through a close-once wrapper, so the descriptor reaches `close(2)` exactly once regardless of which path wins the race.
+
+_Matched automatically by rule `ssdp-socket-double-close`._";
+
+const WATCHDOG_REPLY: &str = ":ninja: **Auto-review: `0x8BADF00D` watchdog — main thread blocked cancelling the Bonjour browser**
+
+The termination reason pins this down: the process failed to terminate within its 5 second budget.
+
+The attributed thread is the **main thread**, parked in `nw_browser_cancel`, reached from `requestLocalNetworkAuthorization`'s `onCancel` handler.
+
+`onCancel` runs synchronously on whichever thread cancels the task, and SwiftUI cancels `.task` work on the main thread while it applies a scene-phase change. `NWBrowser.cancel()` and `NWListener.cancel()` block on an internal Network.framework lock, so when the network queue is busy the main thread stalls past the termination budget and the watchdog kills the app.
+
+**Known cause, fix shipped:** listener/browser teardown is dispatched onto the queue those objects already run on, so the cancelling thread is never blocked.
+
+_Matched automatically by rule `local-network-cancel-watchdog`._";
+
+/// Ordered: the first match wins, so put narrower rules first.
+pub static RULES: &[CrashRule] = &[
+    CrashRule {
+        id: "local-network-cancel-watchdog",
+        title: "0x8BADF00D watchdog cancelling NWBrowser on the main thread",
+        exception_type: None,
+        signal: None,
+        termination_code: Some("0x8badf00d"),
+        all_of: &["nw_browser_cancel"],
+        none_of: &[],
+        reply: WATCHDOG_REPLY,
+    },
+    CrashRule {
+        id: "ssdp-socket-double-close",
+        title: "EXC_GUARD from double-closing the SSDP socket",
+        exception_type: Some(12),
+        signal: None,
+        termination_code: None,
+        all_of: &["scanDevicesContinually", "FileDescriptor._close"],
+        none_of: &[],
+        reply: EXC_GUARD_REPLY,
+    },
+    CrashRule {
+        id: "database-lock-suspension",
+        title: "0xdead10cc suspension while holding the database file lock",
+        exception_type: Some(10),
+        signal: Some(9),
+        termination_code: None,
+        all_of: &["DatabaseFileLock.withExclusiveLock"],
+        none_of: &[],
+        reply: DEAD10CC_REPLY,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEAD10CC_REPORT: &str = r#"
+Crash 1 (version 1.0.0)
+Metadata:
+  appVersion: 1.50
+  deviceType: iPhone14,7
+  exceptionType: 10
+  osVersion: iPhone OS 26.6 (23G71)
+  signal: 9
+Thread 16 (attributed):
+  Roam +0x54788 specialized DatabaseFileLock.withExclusiveLock<A> at /x/DatabaseFileLock.swift:37
+"#;
+
+    const GUARD_REPORT: &str = r#"
+Crash 1 (version 1.0.0)
+Metadata:
+  appVersion: 1.50
+  deviceType: iPhone13,2
+  exceptionType: 12
+  signal: 0
+Thread 13 (attributed):
+  libswiftSystem.dylib +0x12800 FileDescriptor._close samples=1
+    Roam +0x6f5a0 $defer #1  in closure #2 in scanDevicesContinually at /x samples=1
+"#;
+
+    const WATCHDOG_REPORT: &str = r#"
+Crash 1 (version 1.0.0)
+Termination reason: <RBSTerminateContext| domain:10 code:0x8BADF00D explanation:[app<com.msdrigg.roam>:12124] Failed to terminate gracefully after 5.0s
+Metadata:
+  appVersion: 1.50
+  deviceType: iPhone13,1
+  exceptionType: 10
+  signal: 9
+  terminationReason: <RBSTerminateContext| domain:10 code:0x8BADF00D explanation:[app<com.msdrigg.roam>:12124] Failed to terminate gracefully after 5.0s
+Thread 0 (attributed):
+  Network +0x1158200 nw_browser_cancel samples=1
+"#;
+
+    #[test]
+    fn extracts_facts_from_report() {
+        let facts = CrashFacts::from_report(DEAD10CC_REPORT);
+        assert_eq!(facts.app_version.as_deref(), Some("1.50"));
+        assert_eq!(facts.device_type.as_deref(), Some("iPhone14,7"));
+        assert_eq!(facts.os_version.as_deref(), Some("iPhone OS 26.6 (23G71)"));
+        assert_eq!(facts.exception_type, Some(10));
+        assert_eq!(facts.signal, Some(9));
+        assert_eq!(facts.termination_code, None);
+    }
+
+    #[test]
+    fn extracts_termination_code_case_insensitively() {
+        let facts = CrashFacts::from_report(WATCHDOG_REPORT);
+        assert_eq!(facts.termination_code.as_deref(), Some("0x8badf00d"));
+    }
+
+    #[test]
+    fn matches_each_known_crash_to_its_own_rule() {
+        for (report, expected) in [
+            (DEAD10CC_REPORT, "database-lock-suspension"),
+            (GUARD_REPORT, "ssdp-socket-double-close"),
+            (WATCHDOG_REPORT, "local-network-cancel-watchdog"),
+        ] {
+            let facts = CrashFacts::from_report(report);
+            let rule = match_rule(report, &facts).unwrap_or_else(|| panic!("no rule for {expected}"));
+            assert_eq!(rule.id, expected);
+        }
+    }
+
+    #[test]
+    fn watchdog_rule_wins_over_database_rule_for_same_exception_pair() {
+        // The watchdog report is also EXC_CRASH/SIGKILL. It must not fall
+        // through to the database rule, which is why ordering matters.
+        let facts = CrashFacts::from_report(WATCHDOG_REPORT);
+        assert_eq!(facts.exception_type, Some(10));
+        assert_eq!(facts.signal, Some(9));
+        assert_eq!(
+            match_rule(WATCHDOG_REPORT, &facts).map(|r| r.id),
+            Some("local-network-cancel-watchdog")
+        );
+    }
+
+    #[test]
+    fn unknown_crash_matches_nothing() {
+        let report = r#"
+Metadata:
+  exceptionType: 1
+  signal: 11
+Thread 0 (attributed):
+  Roam +0x1 someUnrelatedFunction at /x
+"#;
+        let facts = CrashFacts::from_report(report);
+        assert!(match_rule(report, &facts).is_none());
+    }
+
+    #[test]
+    fn rule_ids_are_unique() {
+        let mut ids: Vec<_> = RULES.iter().map(|r| r.id).collect();
+        ids.sort_unstable();
+        let count = ids.len();
+        ids.dedup();
+        assert_eq!(ids.len(), count, "duplicate rule id");
+    }
+}

--- a/backend/src/database.rs
+++ b/backend/src/database.rs
@@ -391,6 +391,226 @@ impl DatabaseClient {
         Ok(row)
     }
 
+    /// Records a freshly symbolicated crash against its thread.
+    ///
+    /// Upserts so a thread accumulates one row that always describes its most
+    /// recent crash. The review columns are deliberately left untouched: a
+    /// thread reviewed before this crash arrived becomes unreviewed again,
+    /// because `reviewed_at_ms` now trails `latest_crash_at_ms`.
+    pub async fn record_crash_for_review(
+        &self,
+        thread_id: i64,
+        latest_crash_message_id: Option<i64>,
+        facts: &crate::crash_rules::CrashFacts,
+    ) -> Result<CrashReview, anyhow::Error> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        sqlx::query_as::<_, CrashReview>(
+            r#"
+            INSERT INTO crash_reviews (
+                thread_id, latest_crash_message_id, latest_crash_at_ms,
+                app_version, device_type, os_version,
+                exception_type, signal, termination_code
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(thread_id) DO UPDATE SET
+                latest_crash_message_id = excluded.latest_crash_message_id,
+                latest_crash_at_ms = excluded.latest_crash_at_ms,
+                app_version = excluded.app_version,
+                device_type = excluded.device_type,
+                os_version = excluded.os_version,
+                exception_type = excluded.exception_type,
+                signal = excluded.signal,
+                termination_code = excluded.termination_code
+            RETURNING thread_id,
+                latest_crash_message_id,
+                latest_crash_at_ms,
+                app_version,
+                device_type,
+                os_version,
+                exception_type,
+                signal,
+                termination_code,
+                reviewed_at_ms,
+                reviewed_by,
+                reviewed_message_id,
+                matched_rule_id,
+                review_note
+            "#,
+        )
+        .bind(thread_id)
+        .bind(latest_crash_message_id)
+        .bind(now_ms)
+        .bind(&facts.app_version)
+        .bind(&facts.device_type)
+        .bind(&facts.os_version)
+        .bind(facts.exception_type)
+        .bind(facts.signal)
+        .bind(&facts.termination_code)
+        .fetch_one(&self.writer_pool)
+        .await
+        .context("Error recording crash for review")
+    }
+
+    /// Marks a thread reviewed as of now.
+    ///
+    /// `reviewed_by` is free-form: `auto:<rule id>` for the rules engine, or
+    /// whatever a human caller supplies.
+    pub async fn mark_thread_reviewed(
+        &self,
+        thread_id: i64,
+        reviewed_by: Option<&str>,
+        reviewed_message_id: Option<i64>,
+        matched_rule_id: Option<&str>,
+        review_note: Option<&str>,
+    ) -> Result<Option<CrashReview>, anyhow::Error> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        sqlx::query_as::<_, CrashReview>(
+            r#"
+            UPDATE crash_reviews
+            SET reviewed_at_ms = ?,
+                reviewed_by = ?,
+                reviewed_message_id = COALESCE(?, reviewed_message_id),
+                matched_rule_id = COALESCE(?, matched_rule_id),
+                review_note = COALESCE(?, review_note)
+            WHERE thread_id = ?
+            RETURNING thread_id,
+                latest_crash_message_id,
+                latest_crash_at_ms,
+                app_version,
+                device_type,
+                os_version,
+                exception_type,
+                signal,
+                termination_code,
+                reviewed_at_ms,
+                reviewed_by,
+                reviewed_message_id,
+                matched_rule_id,
+                review_note
+            "#,
+        )
+        .bind(now_ms)
+        .bind(reviewed_by)
+        .bind(reviewed_message_id)
+        .bind(matched_rule_id)
+        .bind(review_note)
+        .bind(thread_id)
+        .fetch_optional(&self.writer_pool)
+        .await
+        .context("Error marking thread reviewed")
+    }
+
+    /// Clears review state so a thread shows up as needing attention again.
+    pub async fn mark_thread_unreviewed(
+        &self,
+        thread_id: i64,
+    ) -> Result<Option<CrashReview>, anyhow::Error> {
+        sqlx::query_as::<_, CrashReview>(
+            r#"
+            UPDATE crash_reviews
+            SET reviewed_at_ms = NULL,
+                reviewed_by = NULL,
+                reviewed_message_id = NULL,
+                matched_rule_id = NULL,
+                review_note = NULL
+            WHERE thread_id = ?
+            RETURNING thread_id,
+                latest_crash_message_id,
+                latest_crash_at_ms,
+                app_version,
+                device_type,
+                os_version,
+                exception_type,
+                signal,
+                termination_code,
+                reviewed_at_ms,
+                reviewed_by,
+                reviewed_message_id,
+                matched_rule_id,
+                review_note
+            "#,
+        )
+        .bind(thread_id)
+        .fetch_optional(&self.writer_pool)
+        .await
+        .context("Error marking thread unreviewed")
+    }
+
+    /// Lists tracked crash threads, newest crash first.
+    ///
+    /// `only_unreviewed` applies the same predicate as
+    /// [`CrashReview::is_unreviewed`]. `before_ms` pages backwards through
+    /// `latest_crash_at_ms`; pass the last row's value to get the next page.
+    pub async fn list_crash_reviews(
+        &self,
+        only_unreviewed: bool,
+        app_version: Option<&str>,
+        before_ms: Option<i64>,
+        limit: i64,
+    ) -> Result<Vec<CrashReview>, anyhow::Error> {
+        sqlx::query_as::<_, CrashReview>(
+            r#"
+            SELECT thread_id,
+                latest_crash_message_id,
+                latest_crash_at_ms,
+                app_version,
+                device_type,
+                os_version,
+                exception_type,
+                signal,
+                termination_code,
+                reviewed_at_ms,
+                reviewed_by,
+                reviewed_message_id,
+                matched_rule_id,
+                review_note
+            FROM crash_reviews
+            WHERE (?1 = 0 OR reviewed_at_ms IS NULL OR reviewed_at_ms < latest_crash_at_ms)
+              AND (?2 IS NULL OR app_version = ?2)
+              AND (?3 IS NULL OR latest_crash_at_ms < ?3)
+            ORDER BY latest_crash_at_ms DESC
+            LIMIT ?4
+            "#,
+        )
+        .bind(only_unreviewed)
+        .bind(app_version)
+        .bind(before_ms)
+        .bind(limit)
+        .fetch_all(&self.reader_pool)
+        .await
+        .context("Error listing crash reviews")
+    }
+
+    pub async fn get_crash_review(
+        &self,
+        thread_id: i64,
+    ) -> Result<Option<CrashReview>, anyhow::Error> {
+        sqlx::query_as::<_, CrashReview>(
+            r#"
+            SELECT thread_id,
+                latest_crash_message_id,
+                latest_crash_at_ms,
+                app_version,
+                device_type,
+                os_version,
+                exception_type,
+                signal,
+                termination_code,
+                reviewed_at_ms,
+                reviewed_by,
+                reviewed_message_id,
+                matched_rule_id,
+                review_note
+            FROM crash_reviews
+            WHERE thread_id = ?
+            "#,
+        )
+        .bind(thread_id)
+        .fetch_optional(&self.reader_pool)
+        .await
+        .context("Error getting crash review")
+    }
+
     /// Records a worker-reported failure on the given lease. Clears `leased_at_ms`
     /// so the row is re-leasable, but keeps the incremented `attempts` from the
     /// lease call, which is what caps retries via the `attempts < 3` filter.
@@ -460,6 +680,78 @@ pub struct DeviceInfo {
     pub user_locale: Option<String>,
 }
 
+/// Review state for the crashes in one Discord thread.
+///
+/// See `migrations/20260811000000_crash_reviews.up.sql` for the unreviewed
+/// predicate; [`CrashReview::is_unreviewed`] mirrors it in Rust.
+/// # Why these queries are runtime-checked
+///
+/// Every `crash_reviews` query below uses `sqlx::query_as::<_, CrashReview>`
+/// rather than the compile-time-checked `query_as!` macro used elsewhere in
+/// this file. That is a workaround for an upstream sqlx bug, not a style
+/// choice.
+///
+/// `sqlx_sqlite`'s `StatementHandle::column_nullable` null-checks the database,
+/// table and origin name pointers, then calls `CStr::from_ptr(datatype)` on the
+/// declared type from `sqlite3_table_column_metadata` *without* a null check.
+/// SQLite sets that out-param to NULL for a column declared with no type, and
+/// this schema has one: `users.device_id PRIMARY KEY` in
+/// `20250121024817_initial.up.sql`. Any `query_as!` in the crate therefore
+/// segfaults rustc during macro expansion whenever it can reach a live
+/// database, which is exactly what `cargo sqlx prepare` does. The existing
+/// `.sqlx` cache still works, so offline builds are unaffected — but the cache
+/// cannot be regenerated locally.
+///
+/// Confirmed still unfixed on sqlx main as of 2026-08-11.
+///
+/// ## Retry periodically
+///
+/// Re-test after any sqlx upgrade:
+///
+/// ```text
+/// sqlite3 /tmp/probe.db < migrations/20250121024817_initial.up.sql   # or a copy of the real db
+/// DATABASE_URL="sqlite:///tmp/probe.db" cargo sqlx prepare -- --lib
+/// ```
+///
+/// If that completes without SIGSEGV, convert these back to `query_as!` and
+/// commit the regenerated `.sqlx` entries.
+///
+/// Giving `users.device_id` an explicit `TEXT` type also fixes it — verified
+/// locally, the segfault disappears against a rebuilt schema — but that needs a
+/// full table rebuild migration against production data, so it is deliberately
+/// not bundled with this change.
+#[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
+pub struct CrashReview {
+    #[serde(serialize_with = "i64_to_string")]
+    pub thread_id: i64,
+    #[serde(serialize_with = "crate::utils::i64_to_string_optional")]
+    pub latest_crash_message_id: Option<i64>,
+    pub latest_crash_at_ms: i64,
+    pub app_version: Option<String>,
+    pub device_type: Option<String>,
+    pub os_version: Option<String>,
+    pub exception_type: Option<i64>,
+    pub signal: Option<i64>,
+    pub termination_code: Option<String>,
+    pub reviewed_at_ms: Option<i64>,
+    pub reviewed_by: Option<String>,
+    #[serde(serialize_with = "crate::utils::i64_to_string_optional")]
+    pub reviewed_message_id: Option<i64>,
+    pub matched_rule_id: Option<String>,
+    pub review_note: Option<String>,
+}
+
+impl CrashReview {
+    /// A thread needs attention when it was never reviewed, or when a newer
+    /// crash landed after the last review.
+    pub fn is_unreviewed(&self) -> bool {
+        match self.reviewed_at_ms {
+            None => true,
+            Some(reviewed_at) => reviewed_at < self.latest_crash_at_ms,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PendingSymbolication {
     pub id: String,
@@ -476,4 +768,177 @@ pub struct PendingSymbolication {
     pub failed_at_ms: Option<i64>,
     pub attempts: i64,
     pub last_error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crash_rules::CrashFacts;
+
+    /// The `crash_reviews` queries are runtime-checked (see [`CrashReview`]),
+    /// so nothing verifies their column names or bind order at compile time.
+    /// These tests run the real SQL against a real migrated database, which is
+    /// what stands in for that lost checking.
+    async fn test_client() -> (DatabaseClient, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("test.db");
+        let opts = SqliteConnectOptions::from_str(db_path.to_str().unwrap())
+            .expect("parse opts")
+            .create_if_missing(true);
+        let writer_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts.clone())
+            .await
+            .expect("writer pool");
+        let reader_pool = SqlitePoolOptions::new()
+            .max_connections(2)
+            .connect_with(opts)
+            .await
+            .expect("reader pool");
+        sqlx::migrate!("./migrations")
+            .run(&writer_pool)
+            .await
+            .expect("migrations");
+        (
+            DatabaseClient {
+                reader_pool,
+                writer_pool,
+            },
+            dir,
+        )
+    }
+
+    fn facts(version: &str) -> CrashFacts {
+        CrashFacts {
+            app_version: Some(version.to_string()),
+            device_type: Some("iPhone14,7".to_string()),
+            os_version: Some("iPhone OS 26.6 (23G71)".to_string()),
+            exception_type: Some(10),
+            signal: Some(9),
+            termination_code: Some("0xdead10cc".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn records_and_reviews_a_crash() {
+        let (db, _dir) = test_client().await;
+
+        let recorded = db
+            .record_crash_for_review(42, Some(1001), &facts("1.50"))
+            .await
+            .expect("record");
+        assert_eq!(recorded.thread_id, 42);
+        assert_eq!(recorded.app_version.as_deref(), Some("1.50"));
+        assert_eq!(recorded.exception_type, Some(10));
+        assert!(recorded.is_unreviewed());
+
+        let unreviewed = db
+            .list_crash_reviews(true, None, None, 50)
+            .await
+            .expect("list");
+        assert_eq!(unreviewed.len(), 1);
+
+        let reviewed = db
+            .mark_thread_reviewed(42, Some("auto:test-rule"), Some(2002), Some("test-rule"), None)
+            .await
+            .expect("review")
+            .expect("row exists");
+        assert!(!reviewed.is_unreviewed());
+        assert_eq!(reviewed.reviewed_by.as_deref(), Some("auto:test-rule"));
+        assert_eq!(reviewed.reviewed_message_id, Some(2002));
+
+        assert!(db
+            .list_crash_reviews(true, None, None, 50)
+            .await
+            .expect("list")
+            .is_empty());
+        assert_eq!(
+            db.list_crash_reviews(false, None, None, 50)
+                .await
+                .expect("list all")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_newer_crash_reopens_a_reviewed_thread() {
+        let (db, _dir) = test_client().await;
+        db.record_crash_for_review(7, Some(1), &facts("1.49"))
+            .await
+            .expect("record");
+        db.mark_thread_reviewed(7, Some("someone"), None, None, None)
+            .await
+            .expect("review");
+
+        // Same thread, newer crash: the review is now stale and the thread
+        // should surface again rather than staying silently closed.
+        let reopened = db
+            .record_crash_for_review(7, Some(2), &facts("1.50"))
+            .await
+            .expect("record again");
+        assert!(reopened.is_unreviewed(), "{reopened:?}");
+        assert_eq!(reopened.app_version.as_deref(), Some("1.50"));
+        assert_eq!(reopened.latest_crash_message_id, Some(2));
+
+        let unreviewed = db
+            .list_crash_reviews(true, None, None, 50)
+            .await
+            .expect("list");
+        assert_eq!(unreviewed.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn filters_by_version_and_pages_backwards() {
+        let (db, _dir) = test_client().await;
+        for (thread_id, version) in [(1, "1.49"), (2, "1.50"), (3, "1.50")] {
+            db.record_crash_for_review(thread_id, None, &facts(version))
+                .await
+                .expect("record");
+        }
+
+        let only_150 = db
+            .list_crash_reviews(false, Some("1.50"), None, 50)
+            .await
+            .expect("list");
+        assert_eq!(only_150.len(), 2);
+        assert!(only_150.iter().all(|c| c.app_version.as_deref() == Some("1.50")));
+
+        // Newest first, and `before_ms` excludes everything at or after it.
+        let all = db
+            .list_crash_reviews(false, None, None, 50)
+            .await
+            .expect("list");
+        assert_eq!(all.len(), 3);
+        let cursor = all[0].latest_crash_at_ms;
+        let next_page = db
+            .list_crash_reviews(false, None, Some(cursor), 50)
+            .await
+            .expect("page");
+        assert!(next_page.iter().all(|c| c.latest_crash_at_ms < cursor));
+    }
+
+    #[tokio::test]
+    async fn unreview_clears_state_and_missing_threads_report_none() {
+        let (db, _dir) = test_client().await;
+        db.record_crash_for_review(9, None, &facts("1.50"))
+            .await
+            .expect("record");
+        db.mark_thread_reviewed(9, Some("someone"), Some(5), Some("rule"), Some("note"))
+            .await
+            .expect("review");
+
+        let cleared = db.mark_thread_unreviewed(9).await.expect("unreview").expect("row");
+        assert!(cleared.is_unreviewed());
+        assert_eq!(cleared.reviewed_by, None);
+        assert_eq!(cleared.matched_rule_id, None);
+
+        assert!(db.get_crash_review(9).await.expect("get").is_some());
+        assert!(db.get_crash_review(12345).await.expect("get").is_none());
+        assert!(db
+            .mark_thread_reviewed(12345, None, None, None, None)
+            .await
+            .expect("review missing")
+            .is_none());
+    }
 }

--- a/backend/src/discord.rs
+++ b/backend/src/discord.rs
@@ -338,6 +338,23 @@ impl DiscordClient {
         last_message_id: Option<i64>,
         limit: Option<u8>,
     ) -> Result<Vec<DiscordMessage>, DiscordError> {
+        self.get_messages_paginated(thread_id, last_message_id, None, limit)
+            .await
+    }
+
+    /// Message history with both pagination directions.
+    ///
+    /// `after` walks forward from an id (oldest-first semantics on Discord's
+    /// side), `before` walks backwards from an id, which is how you page
+    /// through history newest-first. Passing neither returns the most recent
+    /// `limit` messages.
+    pub async fn get_messages_paginated(
+        &self,
+        thread_id: i64,
+        after: Option<i64>,
+        before: Option<i64>,
+        limit: Option<u8>,
+    ) -> Result<Vec<DiscordMessage>, DiscordError> {
         let _permit = self.acquire().await.expect("Semaphore should never close");
         self.error_on_locked()?;
 
@@ -348,8 +365,11 @@ impl DiscordClient {
         );
 
         let mut query = Vec::new();
-        if let Some(last_id) = last_message_id {
-            query.push(format!("after={last_id}"));
+        if let Some(after) = after {
+            query.push(format!("after={after}"));
+        }
+        if let Some(before) = before {
+            query.push(format!("before={before}"));
         }
         if let Some(limit) = limit {
             query.push(format!("limit={}", limit.clamp(1, 100)));
@@ -382,6 +402,227 @@ impl DiscordClient {
             })?;
 
         Ok(messages)
+    }
+
+    /// Posts a message, optionally as a threaded reply to an existing one.
+    ///
+    /// Mentions are suppressed: these are automated triage replies and should
+    /// never ping a thread's participants.
+    pub async fn send_reply(
+        &self,
+        thread_id: i64,
+        content: &str,
+        reply_to_message_id: Option<i64>,
+        notify: bool,
+    ) -> Result<DiscordMessage, DiscordError> {
+        let _permit = self.acquire().await.expect("Semaphore should never close");
+        self.error_on_locked()?;
+
+        let url = format!(
+            "{}/channels/{}/messages",
+            Self::DISCORD_API_BASE_URL,
+            thread_id
+        );
+
+        let mut body = serde_json::json!({
+            "content": content,
+            "flags": Self::get_flags(Some(&DiscordMessageOptions { nonce: None, notify })),
+            "allowed_mentions": { "parse": [] },
+        });
+        if let Some(reply_to) = reply_to_message_id {
+            body["message_reference"] = serde_json::json!({
+                "message_id": reply_to.to_string(),
+                "channel_id": thread_id.to_string(),
+                // A deleted parent should downgrade to a plain message rather
+                // than failing the whole post.
+                "fail_if_not_exists": false,
+            });
+        }
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bot {}", self.token))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| DiscordError::ConnectionError(e.into()))?;
+
+        self.update_rate_limit(response.headers());
+        let response = self
+            .except_error_response(response, "sending reply")
+            .await?;
+
+        response
+            .json()
+            .await
+            .map_err(|e| DiscordError::ResponseError(e.into()))
+    }
+
+    /// Fetches one message by id.
+    pub async fn get_message(
+        &self,
+        thread_id: i64,
+        message_id: i64,
+    ) -> Result<DiscordMessage, DiscordError> {
+        let _permit = self.acquire().await.expect("Semaphore should never close");
+        self.error_on_locked()?;
+
+        let url = format!(
+            "{}/channels/{}/messages/{}",
+            Self::DISCORD_API_BASE_URL,
+            thread_id,
+            message_id
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bot {}", self.token))
+            .send()
+            .await
+            .map_err(|e| DiscordError::ConnectionError(e.into()))?;
+
+        self.update_rate_limit(response.headers());
+        let response = self
+            .except_error_response(response, "getting message")
+            .await?;
+
+        response
+            .json()
+            .await
+            .map_err(|e| DiscordError::ResponseError(e.into()))
+    }
+
+    /// Every thread under the support forum channel, active and archived.
+    ///
+    /// Archived threads are paginated by archive timestamp; `max_archived_pages`
+    /// bounds how far back we walk so a caller cannot accidentally pull years of
+    /// history in one request.
+    pub async fn list_all_threads(
+        &self,
+        max_archived_pages: usize,
+    ) -> Result<Vec<Thread>, DiscordError> {
+        let mut threads = self.get_active_threads_updated_since(None).await?;
+        let mut seen: std::collections::HashSet<i64> = threads.iter().map(|t| t.id).collect();
+
+        let mut before: Option<String> = None;
+        for _ in 0..max_archived_pages {
+            let page = self.get_archived_threads_page(before.as_deref()).await?;
+            let is_last = !page.has_more || page.threads.is_empty();
+            before = page
+                .threads
+                .last()
+                .and_then(|t| t.thread_metadata.as_ref())
+                .and_then(|m| m.archive_timestamp.clone());
+            for thread in page.threads {
+                if seen.insert(thread.id) {
+                    threads.push(thread);
+                }
+            }
+            if is_last || before.is_none() {
+                break;
+            }
+        }
+
+        // Most recently active first.
+        threads.sort_by_key(|thread| std::cmp::Reverse(thread.last_message_id));
+        Ok(threads)
+    }
+
+    async fn get_archived_threads_page(
+        &self,
+        before: Option<&str>,
+    ) -> Result<ThreadResponse, DiscordError> {
+        let _permit = self.acquire().await.expect("Semaphore should never close");
+        self.error_on_locked()?;
+
+        let mut url = reqwest::Url::parse(&format!(
+            "{}/channels/{}/threads/archived/public",
+            Self::DISCORD_API_BASE_URL,
+            self.channel_id
+        ))
+        .map_err(|e| DiscordError::ConnectionError(e.into()))?;
+        {
+            // `archive_timestamp` is an ISO-8601 string whose `+00:00` offset
+            // must be percent-encoded or Discord rejects it as unparseable.
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", "100");
+            if let Some(before) = before {
+                query.append_pair("before", before);
+            }
+        }
+
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", format!("Bot {}", self.token))
+            .send()
+            .await
+            .map_err(|e| DiscordError::ConnectionError(e.into()))?;
+
+        self.update_rate_limit(response.headers());
+        let response = self
+            .except_error_response(response, "getting archived threads")
+            .await?;
+
+        response
+            .json()
+            .await
+            .map_err(|e| DiscordError::ResponseError(e.into()))
+    }
+
+    /// Opens an attachment download without reading it into memory.
+    ///
+    /// Returns the live upstream response so the caller can hand
+    /// `bytes_stream()` straight to the HTTP body — attachments here are
+    /// symbolicated crash reports and full diagnostics dumps, which run to
+    /// hundreds of kilobytes each and should never be buffered server-side.
+    ///
+    /// The URL is not taken from the client: callers pass message/attachment
+    /// ids and the URL comes from the looked-up message, so this cannot be
+    /// pointed at arbitrary hosts. The host check is a second line of defence
+    /// in case that ever changes.
+    pub async fn stream_attachment(&self, url: &str) -> Result<Response, DiscordError> {
+        let host = reqwest::Url::parse(url)
+            .ok()
+            .and_then(|parsed| parsed.host_str().map(str::to_string))
+            .ok_or_else(|| DiscordError::InvalidInput(format!("Unparseable attachment url {url}")))?;
+
+        const ALLOWED_SUFFIXES: [&str; 4] = [
+            "discordapp.net",
+            "discordapp.com",
+            "discord.com",
+            "discord.media",
+        ];
+        let allowed = ALLOWED_SUFFIXES
+            .iter()
+            .any(|suffix| host == *suffix || host.ends_with(&format!(".{suffix}")));
+        if !allowed {
+            return Err(DiscordError::InvalidInput(format!(
+                "Refusing to proxy attachment from non-Discord host {host}"
+            )));
+        }
+
+        // Deliberately no semaphore permit: the CDN is not rate limited with the
+        // bot API, and holding a permit for the whole download would serialise
+        // transfers behind the shared request budget.
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| DiscordError::ConnectionError(e.into()))?;
+
+        if !response.status().is_success() {
+            return Err(DiscordError::ApiError {
+                message: format!("Attachment download failed for {url}"),
+                status: response.status(),
+            });
+        }
+
+        Ok(response)
     }
 
     pub async fn get_active_threads_updated_since(
@@ -801,6 +1042,10 @@ mod types {
         #[serde(rename = "type")]
         pub message_type: u8,
         pub attachments: Vec<MessageAttachment>,
+        /// ISO-8601, as Discord sends it. Absent on messages we construct
+        /// ourselves (gateway events, tests).
+        #[serde(default)]
+        pub timestamp: Option<String>,
     }
 
     #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -830,6 +1075,7 @@ mod types {
                 author: DiscordAuthor { id: author_id },
                 message_type,
                 attachments,
+                timestamp: None,
             }
         }
 
@@ -940,15 +1186,32 @@ mod types {
         }
     }
 
-    #[derive(Debug, Clone, Deserialize)]
+    #[derive(Debug, Clone, Deserialize, Serialize)]
     pub struct Thread {
-        #[serde(deserialize_with = "string_to_i64")]
+        // Snowflakes are serialized back out as strings so JSON clients don't
+        // lose precision on them.
+        #[serde(deserialize_with = "string_to_i64", serialize_with = "i64_to_string")]
         pub id: i64,
-        #[serde(default, deserialize_with = "string_to_i64_optional")]
+        #[serde(
+            default,
+            deserialize_with = "string_to_i64_optional",
+            serialize_with = "crate::utils::i64_to_string_optional"
+        )]
         pub parent_id: Option<i64>,
         pub name: String,
-        #[serde(deserialize_with = "string_to_i64")]
+        #[serde(deserialize_with = "string_to_i64", serialize_with = "i64_to_string")]
         pub last_message_id: i64,
+        #[serde(default)]
+        pub thread_metadata: Option<ThreadMetadata>,
+    }
+
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct ThreadMetadata {
+        #[serde(default)]
+        pub archived: bool,
+        /// ISO-8601; doubles as the pagination cursor for archived threads.
+        #[serde(default)]
+        pub archive_timestamp: Option<String>,
     }
 
     #[derive(Deserialize)]
@@ -960,6 +1223,9 @@ mod types {
     #[derive(Deserialize)]
     pub struct ThreadResponse {
         pub threads: Vec<Thread>,
+        /// Only sent on the archived-threads endpoint.
+        #[serde(default)]
+        pub has_more: bool,
     }
 }
 
@@ -989,6 +1255,7 @@ mod tests {
             author: DiscordAuthor { id: 2 },
             message_type: 0,
             attachments: vec![],
+            timestamp: None,
         };
         let normalized = message.normalize();
         assert_eq!(normalized.content, "Hello :ninja: World! :smile:");
@@ -1005,6 +1272,7 @@ mod tests {
             author: DiscordAuthor { id: 3 },
             message_type: 0,
             attachments: vec![],
+            timestamp: None,
         };
         let normalized = message_with_command.normalize();
         assert_eq!(
@@ -1027,6 +1295,7 @@ mod tests {
                 author: DiscordAuthor { id: 2 },
                 message_type: 0,
                 attachments: vec![],
+                timestamp: None,
             },
             DiscordMessage {
                 id: 2,
@@ -1035,6 +1304,7 @@ mod tests {
                 author: DiscordAuthor { id: 2 },
                 message_type: 0,
                 attachments: vec![],
+                timestamp: None,
             },
             DiscordMessage {
                 id: 3,
@@ -1043,6 +1313,7 @@ mod tests {
                 author: DiscordAuthor { id: 2 },
                 message_type: 0,
                 attachments: vec![],
+                timestamp: None,
             },
         ];
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -16,6 +16,7 @@ use crate::symbolicate::{DsymUploadMetadata, StoredDsymArchive, SymbolicationCli
 pub mod ai_responder;
 pub mod apns;
 pub mod cli;
+pub mod crash_rules;
 pub mod database;
 pub mod discord;
 pub mod gateway;

--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -190,6 +190,31 @@ fn router(app_context: AppContext) -> Router {
             "/v2/upload-roam-dsym",
             post(upload_roam_dsym).layer(DefaultBodyLimit::disable()),
         )
+        // Crash review tracking. All of these sit behind the existing
+        // `x-api-key` layer, so a triage client needs the backend key and no
+        // Discord credentials of its own.
+        .route("/v2/crashes", get(list_crashes))
+        .route("/v2/crashes/rules", get(list_crash_rules))
+        .route("/v2/crashes/{thread_id}", get(get_crash))
+        .route(
+            "/v2/crashes/{thread_id}/review",
+            post(review_crash).delete(unreview_crash),
+        )
+        // Discord proxy. Lets the same key read threads, messages and
+        // attachments without ever handling a bot token.
+        .route("/v2/discord/threads", get(list_discord_threads))
+        .route(
+            "/v2/discord/threads/{thread_id}/messages",
+            get(list_discord_messages).post(post_discord_message),
+        )
+        .route(
+            "/v2/discord/threads/{thread_id}/messages/{message_id}",
+            get(get_discord_message),
+        )
+        .route(
+            "/v2/discord/threads/{thread_id}/messages/{message_id}/attachments/{attachment_id}",
+            get(stream_discord_attachment),
+        )
         .route("/v2/symbolicate/lease", get(lease_pending_symbolications))
         .route("/v2/symbolicate/dsym/{uuid}", get(get_dsym_by_uuid))
         .route("/v2/symbolicate/result", post(submit_symbolication_result))
@@ -897,6 +922,333 @@ struct SymbolicationResultRequest {
     error: Option<String>,
 }
 
+// ---------------------------------------------------------------------------
+// Crash review tracking
+// ---------------------------------------------------------------------------
+
+/// Records a freshly symbolicated crash and, when it matches a known rule,
+/// replies in-thread and marks it reviewed.
+///
+/// Crashes that match nothing are left unreviewed on purpose — that is the
+/// queue a human works through via `GET /v2/crashes?unreviewed=true`.
+async fn auto_review_crash(
+    app_context: &AppContext,
+    thread_id: i64,
+    crash_message_id: i64,
+    report: &str,
+) -> anyhow::Result<()> {
+    let facts = crate::crash_rules::CrashFacts::from_report(report);
+    app_context
+        .db_client()
+        .record_crash_for_review(thread_id, Some(crash_message_id), &facts)
+        .await?;
+
+    let Some(rule) = crate::crash_rules::match_rule(report, &facts) else {
+        tracing::info!(
+            thread_id,
+            app_version = ?facts.app_version,
+            "Crash recorded with no matching rule; left for manual review"
+        );
+        return Ok(());
+    };
+
+    let reply = app_context
+        .discord_client()
+        .send_reply(thread_id, rule.reply, Some(crash_message_id), false)
+        .await?;
+
+    app_context
+        .db_client()
+        .mark_thread_reviewed(
+            thread_id,
+            Some(&format!("auto:{}", rule.id)),
+            Some(reply.id),
+            Some(rule.id),
+            Some(rule.title),
+        )
+        .await?;
+
+    tracing::info!(thread_id, rule = rule.id, "Auto-reviewed crash");
+    Ok(())
+}
+
+fn default_crash_limit() -> i64 {
+    50
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListCrashesQuery {
+    /// Only threads whose newest crash has not been reviewed yet.
+    #[serde(default)]
+    unreviewed: bool,
+    /// Exact match on the crash's `appVersion`, e.g. `1.50`.
+    #[serde(default)]
+    app_version: Option<String>,
+    /// Page backwards: pass the previous page's last `latest_crash_at_ms`.
+    #[serde(default)]
+    before_ms: Option<i64>,
+    #[serde(default = "default_crash_limit")]
+    limit: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListCrashesResponse {
+    crashes: Vec<crate::database::CrashReview>,
+    /// Cursor for the next page, or `null` when the last page was returned.
+    next_before_ms: Option<i64>,
+}
+
+async fn list_crashes(
+    State(app_context): State<AppContext>,
+    Query(query): Query<ListCrashesQuery>,
+) -> Result<Json<ListCrashesResponse>, ApiError> {
+    let limit = query.limit.clamp(1, 200);
+    let crashes = app_context
+        .db_client()
+        .list_crash_reviews(
+            query.unreviewed,
+            query.app_version.as_deref(),
+            query.before_ms,
+            limit,
+        )
+        .await
+        .map_err(ApiError::DatabaseError)?;
+
+    // Only advertise another page when this one was full; otherwise the caller
+    // would loop once more just to get an empty list.
+    let next_before_ms = (crashes.len() as i64 == limit)
+        .then(|| crashes.last().map(|c| c.latest_crash_at_ms))
+        .flatten();
+
+    Ok(Json(ListCrashesResponse {
+        crashes,
+        next_before_ms,
+    }))
+}
+
+async fn get_crash(
+    State(app_context): State<AppContext>,
+    Path(thread_id): Path<i64>,
+) -> Result<Json<crate::database::CrashReview>, ApiError> {
+    app_context
+        .db_client()
+        .get_crash_review(thread_id)
+        .await
+        .map_err(ApiError::DatabaseError)?
+        .map(Json)
+        .ok_or_else(|| ApiError::NotFound(format!("No tracked crash for thread {thread_id}")))
+}
+
+async fn list_crash_rules() -> Json<&'static [crate::crash_rules::CrashRule]> {
+    Json(crate::crash_rules::RULES)
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ReviewCrashRequest {
+    /// Free-form attribution, e.g. a person's handle. Defaults to `manual`.
+    #[serde(default)]
+    reviewed_by: Option<String>,
+    /// Id of the reply that resolved this crash, if one was posted.
+    #[serde(default)]
+    reviewed_message_id: Option<String>,
+    #[serde(default)]
+    matched_rule_id: Option<String>,
+    #[serde(default)]
+    note: Option<String>,
+}
+
+async fn review_crash(
+    State(app_context): State<AppContext>,
+    Path(thread_id): Path<i64>,
+    body: Option<Json<ReviewCrashRequest>>,
+) -> Result<Json<crate::database::CrashReview>, ApiError> {
+    let Json(req) = body.unwrap_or_default();
+    let reviewed_message_id =
+        parse_snowflake(req.reviewed_message_id.as_ref(), "reviewed_message_id")?;
+    app_context
+        .db_client()
+        .mark_thread_reviewed(
+            thread_id,
+            Some(req.reviewed_by.as_deref().unwrap_or("manual")),
+            reviewed_message_id,
+            req.matched_rule_id.as_deref(),
+            req.note.as_deref(),
+        )
+        .await
+        .map_err(ApiError::DatabaseError)?
+        .map(Json)
+        .ok_or_else(|| ApiError::NotFound(format!("No tracked crash for thread {thread_id}")))
+}
+
+async fn unreview_crash(
+    State(app_context): State<AppContext>,
+    Path(thread_id): Path<i64>,
+) -> Result<Json<crate::database::CrashReview>, ApiError> {
+    app_context
+        .db_client()
+        .mark_thread_unreviewed(thread_id)
+        .await
+        .map_err(ApiError::DatabaseError)?
+        .map(Json)
+        .ok_or_else(|| ApiError::NotFound(format!("No tracked crash for thread {thread_id}")))
+}
+
+// ---------------------------------------------------------------------------
+// Discord proxy
+// ---------------------------------------------------------------------------
+
+fn default_archived_pages() -> usize {
+    3
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListThreadsQuery {
+    /// How many pages (100 each) of archived threads to walk. 0 = active only.
+    #[serde(default = "default_archived_pages")]
+    archived_pages: usize,
+}
+
+async fn list_discord_threads(
+    State(app_context): State<AppContext>,
+    Query(query): Query<ListThreadsQuery>,
+) -> Result<Json<Vec<crate::discord::Thread>>, ApiError> {
+    let threads = app_context
+        .discord_client()
+        .list_all_threads(query.archived_pages.min(20))
+        .await?;
+    Ok(Json(threads))
+}
+
+/// Snowflake ids arrive as strings (they exceed JS's safe integer range), so
+/// query and body fields carrying them are parsed rather than deserialized
+/// straight to `i64`.
+fn parse_snowflake(value: Option<&String>, field: &str) -> Result<Option<i64>, ApiError> {
+    value
+        .map(|raw| {
+            raw.parse::<i64>()
+                .map_err(|_| ApiError::BadRequest(format!("Invalid {field}: {raw}")))
+        })
+        .transpose()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListMessagesQuery {
+    /// Newest-first pagination: return messages older than this id.
+    #[serde(default)]
+    before: Option<String>,
+    /// Return messages newer than this id.
+    #[serde(default)]
+    after: Option<String>,
+    #[serde(default)]
+    limit: Option<u8>,
+}
+
+async fn list_discord_messages(
+    State(app_context): State<AppContext>,
+    Path(thread_id): Path<i64>,
+    Query(query): Query<ListMessagesQuery>,
+) -> Result<Json<Vec<DiscordMessage>>, ApiError> {
+    let before = parse_snowflake(query.before.as_ref(), "before")?;
+    let after = parse_snowflake(query.after.as_ref(), "after")?;
+    let messages = app_context
+        .discord_client()
+        .get_messages_paginated(thread_id, after, before, query.limit.or(Some(50)))
+        .await?;
+    Ok(Json(messages))
+}
+
+async fn get_discord_message(
+    State(app_context): State<AppContext>,
+    Path((thread_id, message_id)): Path<(i64, i64)>,
+) -> Result<Json<DiscordMessage>, ApiError> {
+    let message = app_context
+        .discord_client()
+        .get_message(thread_id, message_id)
+        .await?;
+    Ok(Json(message))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PostMessageRequest {
+    content: String,
+    /// Post as a threaded reply to this message.
+    #[serde(default)]
+    reply_to_message_id: Option<String>,
+    #[serde(default)]
+    notify: Option<bool>,
+}
+
+async fn post_discord_message(
+    State(app_context): State<AppContext>,
+    Path(thread_id): Path<i64>,
+    Json(req): Json<PostMessageRequest>,
+) -> Result<Json<DiscordMessage>, ApiError> {
+    let reply_to = parse_snowflake(req.reply_to_message_id.as_ref(), "reply_to_message_id")?;
+    let message = app_context
+        .discord_client()
+        .send_reply(
+            thread_id,
+            &req.content,
+            reply_to,
+            req.notify.unwrap_or(false),
+        )
+        .await?;
+    Ok(Json(message))
+}
+
+/// Streams an attachment straight through from Discord's CDN.
+///
+/// The bytes are piped from the upstream response into the client response
+/// without ever being collected: these are symbolicated reports and full
+/// diagnostics dumps, and buffering them would put arbitrary attachment sizes
+/// into backend memory.
+async fn stream_discord_attachment(
+    State(app_context): State<AppContext>,
+    Path((thread_id, message_id, attachment_id)): Path<(i64, i64, i64)>,
+) -> Result<Response, ApiError> {
+    let message = app_context
+        .discord_client()
+        .get_message(thread_id, message_id)
+        .await?;
+
+    let attachment = message
+        .attachments
+        .iter()
+        .find(|a| a.id == attachment_id)
+        .ok_or_else(|| {
+            ApiError::NotFound(format!(
+                "Message {message_id} has no attachment {attachment_id}"
+            ))
+        })?;
+
+    let upstream = app_context
+        .discord_client()
+        .stream_attachment(&attachment.url)
+        .await?;
+
+    let content_type = attachment
+        .content_type
+        .clone()
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    let content_length = upstream.content_length();
+    let filename = attachment.filename.clone();
+
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("inline; filename=\"{}\"", filename.replace('"', "")),
+        );
+    if let Some(len) = content_length {
+        response = response.header(header::CONTENT_LENGTH, len);
+    }
+
+    response
+        .body(Body::from_stream(upstream.bytes_stream()))
+        .map_err(|e| ApiError::SymbolicationError(anyhow::Error::from(e)))
+}
+
 async fn submit_symbolication_result(
     State(app_context): State<AppContext>,
     Json(req): Json<SymbolicationResultRequest>,
@@ -919,7 +1271,7 @@ async fn submit_symbolication_result(
                 ":ninja: MK Diagnostics {} Symbolicated",
                 row.payload_index
             );
-            app_context
+            let posted = app_context
                 .discord_client()
                 .send_message(
                     row.thread_id,
@@ -927,12 +1279,26 @@ async fn submit_symbolication_result(
                     Some(DiscordFileUpload {
                         content_type: "text/plain".to_string(),
                         filename: "symbolicated.txt".to_string(),
-                        data: text.into_bytes(),
+                        data: text.clone().into_bytes(),
                         paired_messages: vec![],
                     }),
                     Some(&DiscordMessageOptions::default()),
                 )
                 .await?;
+
+            // Track the crash for review, then let the rules engine try to
+            // close it out. A failure here must not fail the symbolication
+            // result the worker just delivered, so everything is logged rather
+            // than propagated.
+            if let Err(err) =
+                auto_review_crash(&app_context, row.thread_id, posted.id, &text).await
+            {
+                tracing::error!(
+                    ?err,
+                    thread_id = row.thread_id,
+                    "Failed to record or auto-review crash"
+                );
+            }
 
             if let Err(err) = tokio::fs::remove_file(&row.payload_path).await {
                 if err.kind() != std::io::ErrorKind::NotFound {

--- a/backend/src/symbolicate/sym.rs
+++ b/backend/src/symbolicate/sym.rs
@@ -847,6 +847,30 @@ pub(crate) struct MetricKitCrashDiagnostic {
     pub(crate) call_stack_tree: MetricKitCallStackTree,
     #[serde(default)]
     diagnostic_meta_data: BTreeMap<String, serde_json::Value>,
+    // `MXCrashDiagnostic` declares terminationReason and virtualMemoryRegionInfo
+    // as properties of the diagnostic itself, but `jsonRepresentation()` folds
+    // them into `diagnosticMetaData` alongside exceptionType/signal. Accept
+    // either placement so the field is picked up whichever way it arrives.
+    #[serde(default)]
+    termination_reason: Option<String>,
+    #[serde(default)]
+    virtual_memory_region_info: Option<String>,
+}
+
+impl MetricKitCrashDiagnostic {
+    fn termination_reason(&self) -> Option<String> {
+        self.termination_reason
+            .clone()
+            .or_else(|| metadata_string(&self.diagnostic_meta_data, "terminationReason"))
+            .filter(|reason| !reason.trim().is_empty())
+    }
+
+    fn virtual_memory_region_info(&self) -> Option<String> {
+        self.virtual_memory_region_info
+            .clone()
+            .or_else(|| metadata_string(&self.diagnostic_meta_data, "virtualMemoryRegionInfo"))
+            .filter(|info| !info.trim().is_empty())
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1333,6 +1357,156 @@ fn metadata_string(metadata: &BTreeMap<String, serde_json::Value>, key: &str) ->
         .map(str::to_string)
 }
 
+/// Read a metadata value that MetricKit may encode either as a JSON number or
+/// as a string (`"signal": 9` vs `"signal": "9"` both occur in the wild).
+fn metadata_u64(metadata: &BTreeMap<String, serde_json::Value>, key: &str) -> Option<u64> {
+    let value = metadata.get(key)?;
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|text| text.trim().parse().ok()))
+}
+
+/// Mach exception type names, from `<mach/exception_types.h>`.
+fn exception_type_name(exception_type: u64) -> Option<&'static str> {
+    Some(match exception_type {
+        1 => "EXC_BAD_ACCESS",
+        2 => "EXC_BAD_INSTRUCTION",
+        3 => "EXC_ARITHMETIC",
+        4 => "EXC_EMULATION",
+        5 => "EXC_SOFTWARE",
+        6 => "EXC_BREAKPOINT",
+        7 => "EXC_SYSCALL",
+        8 => "EXC_MACH_SYSCALL",
+        9 => "EXC_RPC_ALERT",
+        10 => "EXC_CRASH",
+        11 => "EXC_RESOURCE",
+        12 => "EXC_GUARD",
+        13 => "EXC_CORPSE_NOTIFY",
+        _ => return None,
+    })
+}
+
+/// Unix signal names, from `<sys/signal.h>`.
+fn signal_name(signal: u64) -> Option<&'static str> {
+    Some(match signal {
+        1 => "SIGHUP",
+        2 => "SIGINT",
+        3 => "SIGQUIT",
+        4 => "SIGILL",
+        5 => "SIGTRAP",
+        6 => "SIGABRT",
+        7 => "SIGEMT",
+        8 => "SIGFPE",
+        9 => "SIGKILL",
+        10 => "SIGBUS",
+        11 => "SIGSEGV",
+        12 => "SIGSYS",
+        13 => "SIGPIPE",
+        14 => "SIGALRM",
+        15 => "SIGTERM",
+        _ => return None,
+    })
+}
+
+/// Plain-English meaning of the well-known OS termination codes that show up in
+/// `MXCrashDiagnostic.terminationReason`.
+fn termination_code_explanation(code: u64) -> Option<&'static str> {
+    Some(match code {
+        0xdead10cc => {
+            "held a file lock or SQLite/WAL lock on a file in a shared app-group \
+             container while being suspended"
+        }
+        0x8badf00d => "watchdog timeout — took too long to launch, resume, suspend, or terminate",
+        0xbaadca11 => "failed to report a PushKit VoIP call after waking for one",
+        0xc00010ff => "terminated because the device got too hot",
+        0xdeadfa11 => "force-quit by the user",
+        0x2bad45ec => "terminated for a security violation",
+        0xbad22222 => "VoIP app was resuming too frequently",
+        0xc51bad01 => "background task ran out of its CPU time budget",
+        0xc51bad02 => "background task ran out of its wall-clock time budget",
+        0xc51bad03 => "background task was not given enough CPU time to finish",
+        _ => return None,
+    })
+}
+
+/// Pull the `Code 0x...` value out of a termination reason string such as
+/// `"Namespace SPRINGBOARD, Code 0xdead10cc"`.
+fn parse_termination_code(termination_reason: &str) -> Option<u64> {
+    let start = termination_reason.find("0x")? + 2;
+    let digits: String = termination_reason[start..]
+        .chars()
+        .take_while(char::is_ascii_hexdigit)
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    u64::from_str_radix(&digits, 16).ok()
+}
+
+/// One-line interpretation of why the process died, assembled from
+/// `exceptionType` / `signal` / `terminationReason`.
+///
+/// The raw numbers alone are hard to read, and `terminationReason` is the field
+/// that distinguishes an OS policy kill (`EXC_CRASH` + `SIGKILL`) from an actual
+/// fault — so when it is present, say what it means; when it is absent, say so
+/// explicitly rather than leaving the reader to guess.
+fn describe_termination(
+    metadata: &BTreeMap<String, serde_json::Value>,
+    termination_reason: Option<&str>,
+) -> Option<String> {
+    let exception_type = metadata_u64(metadata, "exceptionType");
+    let signal = metadata_u64(metadata, "signal");
+
+    let mut parts: Vec<String> = Vec::new();
+
+    if let Some(exception_type) = exception_type {
+        parts.push(match exception_type_name(exception_type) {
+            Some(name) => format!("{name} ({exception_type})"),
+            None => format!("exception type {exception_type}"),
+        });
+    }
+
+    if let Some(signal) = signal {
+        parts.push(match signal_name(signal) {
+            Some(name) => format!("{name} ({signal})"),
+            None => format!("signal {signal}"),
+        });
+    }
+
+    if parts.is_empty() && termination_reason.is_none() {
+        return None;
+    }
+
+    let mut description = parts.join(" / ");
+
+    match termination_reason.and_then(parse_termination_code) {
+        Some(code) => {
+            let explanation = termination_code_explanation(code)
+                .unwrap_or("see the termination reason above for the owning subsystem");
+            if !description.is_empty() {
+                description.push_str(" — ");
+            }
+            description.push_str(&format!("0x{code:x}: {explanation}"));
+        }
+        None => {
+            // EXC_CRASH with SIGKILL is always an OS-initiated kill, never a
+            // fault in the app's own code. Without a terminationReason we can't
+            // say which policy fired, so name the candidates instead of
+            // silently reporting two opaque integers.
+            if exception_type == Some(10) && signal == Some(9) {
+                description.push_str(
+                    " — killed by the OS, not an in-process fault. No terminationReason in \
+                     the payload, so the specific policy is unconfirmed; the usual candidates \
+                     are 0xdead10cc (suspended while holding a file/SQLite lock in a shared \
+                     container), 0x8badf00d (watchdog), and 0xc51bad0* (background task budget).",
+                );
+            }
+        }
+    }
+
+    Some(description)
+}
+
 fn parse_os_build_id(os_version: &str) -> Option<String> {
     let start = os_version.rfind('(')? + 1;
     let end = os_version[start..].find(')')? + start;
@@ -1468,6 +1642,22 @@ fn render_metric_report(
                 .map(|version| format!(" (version {version})"))
                 .unwrap_or_default()
         )?;
+
+        // Surface the termination fields above the metadata dump. They are the
+        // ones that say whether the OS killed the process and why, and they are
+        // easy to miss inside an alphabetical key/value list.
+        let termination_reason = crash.termination_reason();
+        if let Some(termination_reason) = termination_reason.as_deref() {
+            writeln!(report, "Termination reason: {termination_reason}")?;
+        }
+        if let Some(diagnosis) =
+            describe_termination(&crash.diagnostic_meta_data, termination_reason.as_deref())
+        {
+            writeln!(report, "Diagnosis: {diagnosis}")?;
+        }
+        if let Some(region_info) = crash.virtual_memory_region_info() {
+            writeln!(report, "Faulting VM region: {region_info}")?;
+        }
 
         if !crash.diagnostic_meta_data.is_empty() {
             writeln!(report, "Metadata:")?;
@@ -1797,6 +1987,187 @@ mod tests {
             Some("iOS")
         );
         assert_eq!(parse_os_family(""), None);
+    }
+
+    fn crash_from(value: serde_json::Value) -> MetricKitCrashDiagnostic {
+        serde_json::from_value(value).expect("crash diagnostic deserializes")
+    }
+
+    #[test]
+    fn parses_termination_code_from_reason_string() {
+        assert_eq!(
+            parse_termination_code("Namespace SPRINGBOARD, Code 0xdead10cc"),
+            Some(0xdead10cc)
+        );
+        assert_eq!(
+            parse_termination_code("Namespace ASSERTIOND, Code 0x8badf00d"),
+            Some(0x8badf00d)
+        );
+        // Trailing prose after the code must not be swallowed into the digits.
+        assert_eq!(
+            parse_termination_code("Namespace SPRINGBOARD, Code 0xdead10cc (held lock)"),
+            Some(0xdead10cc)
+        );
+        assert_eq!(parse_termination_code("Namespace SPRINGBOARD"), None);
+        assert_eq!(parse_termination_code("Code 0x"), None);
+    }
+
+    #[test]
+    fn reads_termination_reason_from_either_placement() {
+        // Top-level, mirroring MXCrashDiagnostic's property layout.
+        let top_level = crash_from(serde_json::json!({
+            "callStackTree": { "callStacks": [] },
+            "terminationReason": "Namespace SPRINGBOARD, Code 0xdead10cc",
+            "virtualMemoryRegionInfo": "0x1234 is in region 5",
+            "diagnosticMetaData": {}
+        }));
+        assert_eq!(
+            top_level.termination_reason().as_deref(),
+            Some("Namespace SPRINGBOARD, Code 0xdead10cc")
+        );
+        assert_eq!(
+            top_level.virtual_memory_region_info().as_deref(),
+            Some("0x1234 is in region 5")
+        );
+
+        // Folded into diagnosticMetaData, which is what jsonRepresentation() does.
+        let in_metadata = crash_from(serde_json::json!({
+            "callStackTree": { "callStacks": [] },
+            "diagnosticMetaData": {
+                "terminationReason": "Namespace SPRINGBOARD, Code 0xdead10cc"
+            }
+        }));
+        assert_eq!(
+            in_metadata.termination_reason().as_deref(),
+            Some("Namespace SPRINGBOARD, Code 0xdead10cc")
+        );
+
+        // Absent entirely — the case every payload we have on file hits today.
+        let absent = crash_from(serde_json::json!({
+            "callStackTree": { "callStacks": [] },
+            "diagnosticMetaData": { "signal": 9 }
+        }));
+        assert_eq!(absent.termination_reason(), None);
+        assert_eq!(absent.virtual_memory_region_info(), None);
+    }
+
+    #[test]
+    fn describes_termination_with_decoded_reason() {
+        let crash = crash_from(serde_json::json!({
+            "callStackTree": { "callStacks": [] },
+            "diagnosticMetaData": { "exceptionType": 10, "signal": 9 },
+            "terminationReason": "Namespace SPRINGBOARD, Code 0xdead10cc"
+        }));
+
+        let description = describe_termination(
+            &crash.diagnostic_meta_data,
+            crash.termination_reason().as_deref(),
+        )
+        .expect("description");
+
+        assert!(description.contains("EXC_CRASH (10)"), "{description}");
+        assert!(description.contains("SIGKILL (9)"), "{description}");
+        assert!(description.contains("0xdead10cc"), "{description}");
+        assert!(
+            description.contains("shared app-group container"),
+            "{description}"
+        );
+    }
+
+    #[test]
+    fn describes_os_kill_without_a_termination_reason() {
+        // The shape of the payload that prompted this: EXC_CRASH + SIGKILL and
+        // no terminationReason, so the policy can be narrowed but not confirmed.
+        let crash = crash_from(serde_json::json!({
+            "callStackTree": { "callStacks": [] },
+            "diagnosticMetaData": { "exceptionType": 10, "signal": 9 }
+        }));
+
+        let description = describe_termination(
+            &crash.diagnostic_meta_data,
+            crash.termination_reason().as_deref(),
+        )
+        .expect("description");
+
+        assert!(description.contains("killed by the OS"), "{description}");
+        assert!(description.contains("unconfirmed"), "{description}");
+        assert!(description.contains("0xdead10cc"), "{description}");
+    }
+
+    #[test]
+    fn describes_termination_from_string_encoded_numbers() {
+        // MetricKit has shipped these as strings as well as numbers.
+        let crash = crash_from(serde_json::json!({
+            "callStackTree": { "callStacks": [] },
+            "diagnosticMetaData": { "exceptionType": "1", "signal": "11" }
+        }));
+
+        let description = describe_termination(
+            &crash.diagnostic_meta_data,
+            crash.termination_reason().as_deref(),
+        )
+        .expect("description");
+
+        assert_eq!(description, "EXC_BAD_ACCESS (1) / SIGSEGV (11)");
+    }
+
+    #[test]
+    fn describes_nothing_without_termination_fields() {
+        let crash = crash_from(serde_json::json!({
+            "callStackTree": { "callStacks": [] },
+            "diagnosticMetaData": { "deviceType": "iPhone14,7" }
+        }));
+
+        assert_eq!(
+            describe_termination(
+                &crash.diagnostic_meta_data,
+                crash.termination_reason().as_deref()
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn report_surfaces_termination_reason_above_metadata() {
+        let payload: MetricKitPayload = serde_json::from_value(serde_json::json!({
+            "timeStampBegin": "2026-08-10 15:53:00",
+            "timeStampEnd": "2026-08-10 15:53:00",
+            "crashDiagnostics": [{
+                "version": "1.0.0",
+                "callStackTree": { "callStacks": [] },
+                "terminationReason": "Namespace SPRINGBOARD, Code 0xdead10cc",
+                "diagnosticMetaData": {
+                    "exceptionType": 10,
+                    "signal": 9,
+                    "deviceType": "iPhone14,7"
+                }
+            }]
+        }))
+        .expect("payload deserializes");
+
+        let report = render_metric_report(
+            &empty_diagnostics(),
+            &empty_device_info(),
+            &payload,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect("report renders");
+
+        assert!(
+            report.contains("Termination reason: Namespace SPRINGBOARD, Code 0xdead10cc"),
+            "{report}"
+        );
+        assert!(
+            report.contains("Diagnosis: EXC_CRASH (10) / SIGKILL (9)"),
+            "{report}"
+        );
+        assert!(report.contains("shared app-group container"), "{report}");
+
+        // The decoded lines must come before the raw key/value dump.
+        let diagnosis_at = report.find("Diagnosis:").expect("diagnosis line");
+        let metadata_at = report.find("Metadata:").expect("metadata block");
+        assert!(diagnosis_at < metadata_at, "{report}");
     }
 
     #[test]

--- a/backend/src/utils.rs
+++ b/backend/src/utils.rs
@@ -38,6 +38,18 @@ where
     serializer.serialize_str(&number.to_string())
 }
 
+/// Snowflake IDs exceed JavaScript's safe integer range, so they go over the
+/// wire as strings. `null` stays `null`.
+pub fn i64_to_string_optional<S>(number: &Option<i64>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match number {
+        Some(number) => serializer.serialize_str(&number.to_string()),
+        None => serializer.serialize_none(),
+    }
+}
+
 pub fn string_to_i64_optional<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
 where
     D: Deserializer<'de>,


### PR DESCRIPTION
MetricKit reported EXC_CRASH (10) / SIGKILL (9) with every thread idle
except a GRDB writer mid-write. That is the 0xdead10cc signature: the
process was suspended while holding an exclusive flock on the lock file
in the shared app-group container, plus the SQLite/WAL locks on
Roam.sqlite beside it. A suspended lock holder can block RoamWidgets
indefinitely, so the system kills it.

The write came from continual SSDP discovery, which kept running into
the background and wrote each discovered device straight to the shared
database.

Three changes:

- Hold a background-task assertion across persistent writes, so the
  process stays alive long enough to commit and unlock. Covers every
  write path at once via writeAsync, plus the persistent-database retry
  that opens (and migrates) then merges.

- Take the file lock around the transaction only. performWrite and
  mergeVolatileSnapshot were holding it across a full snapshot reload
  that scans every table, which widened the suspension window for no
  benefit. The reload now runs unlocked on the same writer connection.

- Stop automatic discovery while backgrounded, at every callsite that
  starts it, removing the main source of writes still in flight at
  suspension time. Manual pull-to-refresh is untouched since it only
  runs in the foreground, and macOS is untouched since it has no
  equivalent suspension policy.

retryOpeningPersistentDatabase becomes async and so is now re-entrant;
it re-checks whether another call already installed a persistent
database before installing its own.